### PR TITLE
Add QueryParams middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ end
 
 - `Tesla.Middleware.BaseUrl` - set base url for all request
 - `Tesla.Middleware.Headers` - set request headers
+- `Tesla.Middleware.QueryParams` - set query parameters
 
 ### JSON
 NOTE: requires [exjsx](https://github.com/talentdeficit/exjsx) as dependency

--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -28,8 +28,8 @@ defmodule Tesla.Middleware.QueryParams do
     query = for {key, val} <- query, into: %{}, do: {to_string(key), val}
     uri = URI.parse(url)
     q = if uri.query do
-      old_query = URI.decode_query(uri.query)
-      Map.merge(old_query, query)
+      env_query = URI.decode_query(uri.query)
+      Map.merge(query, env_query)
     else
       query
     end

--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -23,16 +23,13 @@ defmodule Tesla.Middleware.QueryParams do
     run.(env)
   end
 
-  def query_from_url(url) do
-    URI.parse(url).query
-  end
-
+  @spec merge_url_and_query(String.t, %{}) :: String.t
   def merge_url_and_query(url, query) do
+    query = for {key, val} <- query, into: %{}, do: {to_string(key), val}
     uri = URI.parse(url)
-    query_str = uri.query
-    q = if query_str do
-      old_query = URI.decode_query(query_str)
-      Map.merge(query, old_query)
+    q = if uri.query do
+      old_query = URI.decode_query(uri.query)
+      Map.merge(old_query, query)
     else
       query
     end

--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -17,6 +17,30 @@ defmodule Tesla.Middleware.Headers do
   end
 end
 
+defmodule Tesla.Middleware.QueryParams do
+  def call(env, run, query) do
+    env = %{env | url: merge_url_and_query(env.url, query)}
+    run.(env)
+  end
+
+  def query_from_url(url) do
+    URI.parse(url).query
+  end
+
+  def merge_url_and_query(url, query) do
+    uri = URI.parse(url)
+    query_str = uri.query
+    q = if query_str do
+      old_query = URI.decode_query(query_str)
+      Map.merge(query, old_query)
+    else
+      query
+    end
+
+    uri |> Map.put(:query, URI.encode_query(q)) |> URI.to_string
+  end
+end
+
 defmodule Tesla.Middleware.DecodeRels do
   def call(env, run, []) do
     env = run.(env)

--- a/test/tesla/middleware/core_test.exs
+++ b/test/tesla/middleware/core_test.exs
@@ -22,10 +22,10 @@ defmodule CoreTest do
     assert env.url == "http://example.com?access_token=secret_token"
   end
 
-  test "Tesla.Middlware.QueryParams - joining onto existing query params" do
-    e = %Tesla.Env{url: "http://example.com?foo=bar&access_token=old_token"}
-    env = call(Tesla.Middleware.QueryParams, e, %{access_token: "secret_token"})
-    assert env.url == "http://example.com?access_token=secret_token&foo=bar"
+  test "Tesla.Middlware.QueryParams - should not override existing key" do
+    e = %Tesla.Env{url: "http://example.com?foo=bar&access_token=params_token"}
+    env = call(Tesla.Middleware.QueryParams, e, %{access_token: "middleware_token"})
+    assert env.url == "http://example.com?access_token=params_token&foo=bar"
   end
 
   test "Tesla.Middleware.Headers" do

--- a/test/tesla/middleware/core_test.exs
+++ b/test/tesla/middleware/core_test.exs
@@ -16,6 +16,18 @@ defmodule CoreTest do
     assert env.url == "http://other.foo"
   end
 
+  test "Tesla.Middlware.QueryParams - joining default query params" do
+    e = %Tesla.Env{url: "http://example.com"}
+    env = call(Tesla.Middleware.QueryParams, e, %{access_token: "secret_token"})
+    assert env.url == "http://example.com?access_token=secret_token"
+  end
+
+  test "Tesla.Middlware.QueryParams - joining onto existing query params" do
+    e = %Tesla.Env{url: "http://example.com?foo=bar"}
+    env = call(Tesla.Middleware.QueryParams, e, %{access_token: "secret_token"})
+    assert env.url == "http://example.com?access_token=secret_token&foo=bar"
+  end
+
   test "Tesla.Middleware.Headers" do
     env = call(Tesla.Middleware.Headers, %{headers: %{}}, %{'Content-Type' => 'text/plain'})
     assert env.headers == %{'Content-Type' => 'text/plain'}

--- a/test/tesla/middleware/core_test.exs
+++ b/test/tesla/middleware/core_test.exs
@@ -23,7 +23,7 @@ defmodule CoreTest do
   end
 
   test "Tesla.Middlware.QueryParams - joining onto existing query params" do
-    e = %Tesla.Env{url: "http://example.com?foo=bar"}
+    e = %Tesla.Env{url: "http://example.com?foo=bar&access_token=old_token"}
     env = call(Tesla.Middleware.QueryParams, e, %{access_token: "secret_token"})
     assert env.url == "http://example.com?access_token=secret_token&foo=bar"
   end


### PR DESCRIPTION
First off, I'm excited to see an elixir HTTP library building on the concepts from Faraday. Plug and rack middleware are a powerful concept. Thank you for writing this library.


This PR adds a middleware for including default query params. Does the heavy
lifting of URI manipulation with URI module.

This middleware is helpful because certain APIs require access_tokens in
their query_params and it's helpful to set these as default using a
middlware.

```
defmodule Github.Api do
  use Tesla.Builder

  plug Tesla.Middleware.BaseUrl, "https://api.github.com"
  plug Tesla.Middleware.Headers, %{'User-Agent' => 'elixir'}

  plug Tesla.Middleware.QueryParams, %{access_token: "XXXXXXXXXXXXXXXXXXXXXXX"}
  plug Tesla.Middleware.DecodeJson

  adapter Tesla.Adapter.Ibrowse
end
```