### PR TITLE
Handle mission options for EncodeJson / DecodeJson

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -87,7 +87,9 @@ end
 
 
 defmodule Tesla.Middleware.DecodeJson do
-  def call(env, next, opts \\ []) do
+  def call(env, next, opts) do
+    opts = opts || []
+
     env
     |> Tesla.run(next)
     |> Tesla.Middleware.JSON.decode(opts)
@@ -95,7 +97,9 @@ defmodule Tesla.Middleware.DecodeJson do
 end
 
 defmodule Tesla.Middleware.EncodeJson do
-  def call(env, next, opts \\ []) do
+  def call(env, next, opts) do
+    opts = opts || []
+
     env
     |> Tesla.Middleware.JSON.encode(opts)
     |> Tesla.run(next)

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -68,4 +68,25 @@ defmodule JsonTest do
   test "decode if Content-Type is text/javascript" do
     assert Client.get("/facebook").body == %{"friends" => 1000000}
   end
+
+  defmodule EncodeDecodeJsonClient do
+    use Tesla
+
+    plug Tesla.Middleware.DecodeJson
+    plug Tesla.Middleware.EncodeJson
+
+    adapter fn (env) ->
+      {status, headers, body} = case env.url do
+        "/foo2baz" ->
+          {200, %{'Content-Type' => 'application/json'}, env.body |> String.replace("foo", "baz")}
+      end
+
+      %{env | status: status, headers: headers, body: body}
+    end
+  end
+
+  test "EncodeJson / DecodeJson work without options" do
+    alias EncodeDecodeJsonClient, as: EDJClient
+    assert EDJClient.post("/foo2baz", %{"foo" => "bar"}).body == %{"baz" => "bar"}
+  end
 end


### PR DESCRIPTION
When using `Tesla.Middleware.EncodeJson` or `Tesla.Middleware.DecodeJson` without any options, like:

```elixir
  defmodule EncodeDecodeJsonClient do
    use Tesla

    plug Tesla.Middleware.DecodeJson
    plug Tesla.Middleware.EncodeJson

    # ...
  end

```

..one gets a `FunctionClauseError` when it tries to resolve what JSON engine to use:

```
JsonTest
  ...
  * test EncodeJson / DecodeJson works without options (3.2ms)

  1) test EncodeJson / DecodeJson works without options (JsonTest)
     test/tesla/middleware/json_test.exs:88
     ** (FunctionClauseError) no function clause matching in Keyword.get/3
     stacktrace:
       (elixir) lib/keyword.ex:150: Keyword.get(nil, :engine, Poison)
       (tesla) lib/tesla/middleware/json.ex:79: Tesla.Middleware.JSON.do_process/3
       (tesla) lib/tesla/middleware/json.ex:68: Tesla.Middleware.JSON.process/3
       (elixir) lib/map.ex:513: Map.update!/3
       (tesla) lib/tesla/middleware/json.ex:28: Tesla.Middleware.JSON.encode/2
       (tesla) lib/tesla/middleware/json.ex:104: Tesla.Middleware.EncodeJson.call/3
       (tesla) lib/tesla/middleware/json.ex:94: Tesla.Middleware.DecodeJson.call/3
       test/tesla/middleware/json_test.exs:90: (test)

  * test Tesla.Middleware.EncodeJson: return Tesla.Env and execute rest of the stack (0.3ms)
  ...
```

This is due to `nil` being passed when no options are given; so even though `Keyword.get` has a default choice to use, it raises an error instead since it isn't passed a list.

Fix this by setting opts to an empty list if it's falsy (:false or :nil), just like the combined JSON middleware does.