### PR TITLE
Builder options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,36 @@ GitHub.get("/user/teamon/repos")
 GitHub.user_repos("teamon")
 ```
 
+### Supported options
+
+Tesla.Builder allows to pass following options
+
+#### `:only` and `:except`
+
+Useful when you don't need functions for all http verbs to be generated.
+
+```ex
+  #examples
+  use Tesla, only: ~w(get post)a
+  use Tesla, only: [:delete]
+  use Tesla, except: [:delete, :options]
+```
+
+#### `:docs`
+
+You can disable docs for tesla generated functions if you don't want them to be included in your own project docs.
+
+```ex
+  defmodule MyProject.ApiModule do
+    @moduledoc "Module that does something"
+
+    use Tesla, docs: false
+
+    @doc "Function to get something from somewhere"
+    def custom_function(), do: get(...)
+  end
+```
+
 ## Adapters
 
 Tesla has support for different adapters that do the actual HTTP request processing.

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -50,48 +50,58 @@ defmodule Tesla.Builder do
       Module.register_attribute(__MODULE__, :__middleware__, accumulate: true)
       Module.register_attribute(__MODULE__, :__adapter__, [])
 
-      @type option :: {:method,   Tesla.Env.method}  |
-                      {:url,      Tesla.Env.url}     |
-                      {:query,    Tesla.Env.query}   |
-                      {:headers,  Tesla.Env.headers} |
-                      {:body,     Tesla.Env.body}    |
-                      {:opts,     Tesla.Env.opts}
+      docs = Keyword.get(unquote(opts), :docs, true)
 
-      @doc """
-      Perform a request using client function
+      if docs do
+        @type option :: {:method,   Tesla.Env.method}  |
+                        {:url,      Tesla.Env.url}     |
+                        {:query,    Tesla.Env.query}   |
+                        {:headers,  Tesla.Env.headers} |
+                        {:body,     Tesla.Env.body}    |
+                        {:opts,     Tesla.Env.opts}
 
-      Options:
-      - `:method`   - the request method, one of [:head, :get, :delete, :trace, :options, :post, :put, :patch]
-      - `:url`      - either full url e.g. "http://example.com/some/path" or just "/some/path" if using `Tesla.Middleware.BaseUrl`
-      - `:query`    - a keyword list of query params, e.g. `[page: 1, per_page: 100]`
-      - `:headers`  - a keyworld list of headers, e.g. `[{"content-type", "text/plain"}]`
-      - `:body`     - depends on used middleware:
-          - by default it can be a binary
-          - if using e.g. JSON encoding middleware it can be a nested map
-          - if adapter supports it it can be a Stream with any of the above
-      - `:opts`     - custom, per-request middleware or adapter options
+        @doc """
+        Perform a request using client function
 
-      Examples:
+        Options:
+        - `:method`   - the request method, one of [:head, :get, :delete, :trace, :options, :post, :put, :patch]
+        - `:url`      - either full url e.g. "http://example.com/some/path" or just "/some/path" if using `Tesla.Middleware.BaseUrl`
+        - `:query`    - a keyword list of query params, e.g. `[page: 1, per_page: 100]`
+        - `:headers`  - a keyworld list of headers, e.g. `[{"content-type", "text/plain"}]`
+        - `:body`     - depends on used middleware:
+            - by default it can be a binary
+            - if using e.g. JSON encoding middleware it can be a nested map
+            - if adapter supports it it can be a Stream with any of the above
+        - `:opts`     - custom, per-request middleware or adapter options
 
-          iex> ExampleApi.request(method: :get, url: "/users/path")
+        Examples:
 
-      You can also use shortcut methods like:
+            iex> ExampleApi.request(method: :get, url: "/users/path")
 
-          iex> ExampleApi.get("/users/1")
+        You can also use shortcut methods like:
 
-      or
+            iex> ExampleApi.get("/users/1")
 
-          iex> myclient |> ExampleApi.post("/users", %{name: "Jon"})
-      """
-      @spec request(Tesla.Env.client, [option]) :: Tesla.Env.t
+        or
+
+            iex> myclient |> ExampleApi.post("/users", %{name: "Jon"})
+        """
+        @spec request(Tesla.Env.client, [option]) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def request(client, options) do
         Tesla.perform_request(__MODULE__, client, options)
       end
 
-      @doc """
-      Perform a request. See `request/2` for available options.
-      """
+      if docs do
+        @doc """
+        Perform a request. See `request/2` for available options.
+        """
       @spec request([option]) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def request(options) do
         Tesla.perform_request(__MODULE__, options)
       end
@@ -175,93 +185,125 @@ defmodule Tesla.Builder do
       |> Enum.reject(&(not &1 in Keyword.get(opts, :only, @http_verbs)))
       |> Enum.reject(&(&1 in Keyword.get(opts, :except, [])))
 
-    Enum.map selected_verbs, &generate_api/1
+    Enum.map selected_verbs, &generate_api(&1, Keyword.get(opts, :docs, true))
   end
 
-  defp generate_api(method) when method in [:post, :put, :patch] do
+  defp generate_api(method, docs) when method in [:post, :put, :patch] do
     quote do
-      @doc """
-      Perform a #{unquote(method |> to_string |> String.upcase)} request.
-      See `request/1` or `request/2` for options definition.
+      if unquote(docs) do
+        @doc """
+        Perform a #{unquote(method |> to_string |> String.upcase)} request.
+        See `request/1` or `request/2` for options definition.
 
-      Example
-          iex> myclient |> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"}, query: [scope: "admin"])
-      """
-      @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, Tesla.Env.body, [option]) :: Tesla.Env.t
+        Example
+            iex> myclient |> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"}, query: [scope: "admin"])
+        """
+        @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, Tesla.Env.body, [option]) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(client, url, body, options) when is_function(client) do
         request(client, [method: unquote(method), url: url, body: body] ++ options)
       end
 
-      @doc """
-      Perform a #{unquote(method |> to_string |> String.upcase)} request.
-      See `request/1` or `request/2` for options definition.
+      if unquote(docs) do
+        @doc """
+        Perform a #{unquote(method |> to_string |> String.upcase)} request.
+        See `request/1` or `request/2` for options definition.
 
-      Example
-          iex> myclient |> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"})
-          iex> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"}, query: [scope: "admin"])
-      """
-      @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, Tesla.Env.body) :: Tesla.Env.t
+        Example
+            iex> myclient |> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"})
+            iex> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"}, query: [scope: "admin"])
+        """
+        @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, Tesla.Env.body) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(client, url, body) when is_function(client) do
         request(client, method: unquote(method), url: url, body: body)
       end
-      @spec unquote(method)(Tesla.Env.url, Tesla.Env.body, [option]) :: Tesla.Env.t
+      if unquote(docs) do
+        @spec unquote(method)(Tesla.Env.url, Tesla.Env.body, [option]) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(url, body, options) do
         request([method: unquote(method), url: url, body: body] ++ options)
       end
 
-      @doc """
-      Perform a #{unquote(method |> to_string |> String.upcase)} request.
-      See `request/1` or `request/2` for options definition.
+      if unquote(docs) do
+        @doc """
+        Perform a #{unquote(method |> to_string |> String.upcase)} request.
+        See `request/1` or `request/2` for options definition.
 
-      Example
-          iex> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"})
-      """
-      @spec unquote(method)(Tesla.Env.url, Tesla.Env.body) :: Tesla.Env.t
+        Example
+            iex> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"})
+        """
+        @spec unquote(method)(Tesla.Env.url, Tesla.Env.body) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(url, body) do
         request(method: unquote(method), url: url, body: body)
       end
     end
   end
 
-  defp generate_api(method) when method in [:head, :get, :delete, :trace, :options] do
+  defp generate_api(method, docs) when method in [:head, :get, :delete, :trace, :options] do
     quote do
-      @doc """
-      Perform a #{unquote(method |> to_string |> String.upcase)} request.
-      See `request/1` or `request/2` for options definition.
+      if unquote(docs) do
+        @doc """
+        Perform a #{unquote(method |> to_string |> String.upcase)} request.
+        See `request/1` or `request/2` for options definition.
 
-      Example
-          iex> myclient |> ExampleApi.#{unquote(method)}("/users", query: [page: 1])
-      """
-      @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, [option]) :: Tesla.Env.t
+        Example
+            iex> myclient |> ExampleApi.#{unquote(method)}("/users", query: [page: 1])
+        """
+        @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, [option]) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(client, url, options) when is_function(client) do
         request(client, [method: unquote(method), url: url] ++ options)
       end
 
-      @doc """
-      Perform a #{unquote(method |> to_string |> String.upcase)} request.
-      See `request/1` or `request/2` for options definition.
+      if unquote(docs) do
+        @doc """
+        Perform a #{unquote(method |> to_string |> String.upcase)} request.
+        See `request/1` or `request/2` for options definition.
 
-      Example
-          iex> myclient |> ExampleApi.#{unquote(method)}("/users")
-          iex> ExampleApi.#{unquote(method)}("/users", query: [page: 1])
-      """
-      @spec unquote(method)(Tesla.Env.client, Tesla.Env.url) :: Tesla.Env.t
+        Example
+            iex> myclient |> ExampleApi.#{unquote(method)}("/users")
+            iex> ExampleApi.#{unquote(method)}("/users", query: [page: 1])
+        """
+        @spec unquote(method)(Tesla.Env.client, Tesla.Env.url) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(client, url) when is_function(client) do
         request(client, method: unquote(method), url: url)
       end
-      @spec unquote(method)(Tesla.Env.url, [option]) :: Tesla.Env.t
+      if unquote(docs) do
+        @spec unquote(method)(Tesla.Env.url, [option]) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(url, options) do
         request([method: unquote(method), url: url] ++ options)
       end
 
-      @doc """
-      Perform a #{unquote(method |> to_string |> String.upcase)} request.
-      See `request/1` or `request/2` for options definition.
+      if unquote(docs) do
+        @doc """
+        Perform a #{unquote(method |> to_string |> String.upcase)} request.
+        See `request/1` or `request/2` for options definition.
 
-      Example
-          iex> ExampleApi.#{unquote(method)}("/users")
-      """
-      @spec unquote(method)(Tesla.Env.url) :: Tesla.Env.t
+        Example
+            iex> ExampleApi.#{unquote(method)}("/users")
+        """
+        @spec unquote(method)(Tesla.Env.url) :: Tesla.Env.t
+      else
+        @doc false
+      end
       def unquote(method)(url) do
         request(method: unquote(method), url: url)
       end

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -40,38 +40,18 @@ defmodule Tesla.Env do
             __client__: nil
 end
 
-defmodule Tesla.DynamicDef do
-  defmacro dynamic_def(true, definition, do: body) do
-    quote do
-      defp unquote(definition) do
-        unquote(body)
-      end
-    end
-  end
-
-  defmacro dynamic_def(_, definition, do: body) do
-    quote do
-      def unquote(definition) do
-        unquote(body)
-      end
-    end
-  end
-end
-
 defmodule Tesla.Builder do
   @http_verbs ~w(head get delete trace options post put patch)a
 
   defmacro __using__(opts \\ []) do
     opts = Macro.prewalk(opts, &Macro.expand(&1, __CALLER__))
-    private = Keyword.get(opts, :private)
+    docs = Keyword.get(opts, :docs, true)
 
     quote do
-      import Tesla.DynamicDef
-
       Module.register_attribute(__MODULE__, :__middleware__, accumulate: true)
       Module.register_attribute(__MODULE__, :__adapter__, [])
 
-      unless unquote(private) do
+      if unquote(docs) do
         @type option :: {:method,   Tesla.Env.method}  |
                         {:url,      Tesla.Env.url}     |
                         {:query,    Tesla.Env.query}   |
@@ -106,18 +86,22 @@ defmodule Tesla.Builder do
             iex> myclient |> ExampleApi.post("/users", %{name: "Jon"})
         """
         @spec request(Tesla.Env.client, [option]) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), request(client, options) do
+      def request(client, options) do
         Tesla.perform_request(__MODULE__, client, options)
       end
 
-      unless unquote(private) do
+      if unquote(docs) do
         @doc """
         Perform a request. See `request/2` for available options.
         """
       @spec request([option]) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), request(options) do
+      def request(options) do
         Tesla.perform_request(__MODULE__, options)
       end
 
@@ -200,12 +184,12 @@ defmodule Tesla.Builder do
       |> Enum.reject(&(not &1 in Keyword.get(opts, :only, @http_verbs)))
       |> Enum.reject(&(&1 in Keyword.get(opts, :except, [])))
 
-    Enum.map selected_verbs, &generate_api(&1, Keyword.get(opts, :private))
+    Enum.map selected_verbs, &generate_api(&1, Keyword.get(opts, :docs, true))
   end
 
-  defp generate_api(method, private) when method in [:post, :put, :patch] do
+  defp generate_api(method, docs) when method in [:post, :put, :patch] do
     quote do
-      unless unquote(private) do
+      if unquote(docs) do
         @doc """
         Perform a #{unquote(method |> to_string |> String.upcase)} request.
         See `request/1` or `request/2` for options definition.
@@ -214,12 +198,14 @@ defmodule Tesla.Builder do
             iex> myclient |> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"}, query: [scope: "admin"])
         """
         @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, Tesla.Env.body, [option]) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(client, url, body, options) when is_function(client) do
+      def unquote(method)(client, url, body, options) when is_function(client) do
         request(client, [method: unquote(method), url: url, body: body] ++ options)
       end
 
-      unless unquote(private) do
+      if unquote(docs) do
         @doc """
         Perform a #{unquote(method |> to_string |> String.upcase)} request.
         See `request/1` or `request/2` for options definition.
@@ -229,18 +215,22 @@ defmodule Tesla.Builder do
             iex> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"}, query: [scope: "admin"])
         """
         @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, Tesla.Env.body) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(client, url, body) when is_function(client) do
+      def unquote(method)(client, url, body) when is_function(client) do
         request(client, method: unquote(method), url: url, body: body)
       end
-      unless unquote(private) do
+      if unquote(docs) do
         @spec unquote(method)(Tesla.Env.url, Tesla.Env.body, [option]) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(url, body, options) do
+      def unquote(method)(url, body, options) do
         request([method: unquote(method), url: url, body: body] ++ options)
       end
 
-      unless unquote(private) do
+      if unquote(docs) do
         @doc """
         Perform a #{unquote(method |> to_string |> String.upcase)} request.
         See `request/1` or `request/2` for options definition.
@@ -249,16 +239,18 @@ defmodule Tesla.Builder do
             iex> ExampleApi.#{unquote(method)}("/users", %{name: "Jon"})
         """
         @spec unquote(method)(Tesla.Env.url, Tesla.Env.body) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(url, body) do
+      def unquote(method)(url, body) do
         request(method: unquote(method), url: url, body: body)
       end
     end
   end
 
-  defp generate_api(method, private) when method in [:head, :get, :delete, :trace, :options] do
+  defp generate_api(method, docs) when method in [:head, :get, :delete, :trace, :options] do
     quote do
-      unless unquote(private) do
+      if unquote(docs) do
         @doc """
         Perform a #{unquote(method |> to_string |> String.upcase)} request.
         See `request/1` or `request/2` for options definition.
@@ -267,12 +259,14 @@ defmodule Tesla.Builder do
             iex> myclient |> ExampleApi.#{unquote(method)}("/users", query: [page: 1])
         """
         @spec unquote(method)(Tesla.Env.client, Tesla.Env.url, [option]) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(client, url, options) when is_function(client) do
+      def unquote(method)(client, url, options) when is_function(client) do
         request(client, [method: unquote(method), url: url] ++ options)
       end
 
-      unless unquote(private) do
+      if unquote(docs) do
         @doc """
         Perform a #{unquote(method |> to_string |> String.upcase)} request.
         See `request/1` or `request/2` for options definition.
@@ -282,18 +276,22 @@ defmodule Tesla.Builder do
             iex> ExampleApi.#{unquote(method)}("/users", query: [page: 1])
         """
         @spec unquote(method)(Tesla.Env.client, Tesla.Env.url) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(client, url) when is_function(client) do
+      def unquote(method)(client, url) when is_function(client) do
         request(client, method: unquote(method), url: url)
       end
-      unless unquote(private) do
+      if unquote(docs) do
         @spec unquote(method)(Tesla.Env.url, [option]) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(url, options) do
+      def unquote(method)(url, options) do
         request([method: unquote(method), url: url] ++ options)
       end
 
-      unless unquote(private) do
+      if unquote(docs) do
         @doc """
         Perform a #{unquote(method |> to_string |> String.upcase)} request.
         See `request/1` or `request/2` for options definition.
@@ -302,8 +300,10 @@ defmodule Tesla.Builder do
             iex> ExampleApi.#{unquote(method)}("/users")
         """
         @spec unquote(method)(Tesla.Env.url) :: Tesla.Env.t
+      else
+        @doc false
       end
-      dynamic_def unquote(private), unquote(method)(url) do
+      def unquote(method)(url) do
         request(method: unquote(method), url: url)
       end
     end

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -91,11 +91,6 @@ defmodule TeslaTest do
       refute :delete in functions
       assert Enum.all?(@http_verbs -- [:delete], &(&1 in functions))
     end
-
-    test "generate private functions" do
-      assert Mc.Private.custom_get("/").status == 200
-      assert_raise(UndefinedFunctionError, fn -> Mc.Private.get("/") end)
-    end
   end
 
 

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -40,7 +40,17 @@ defmodule TeslaTest do
           Map.put(env, :url, "#{env.url}/anon")
         end
       end
+
+      defmodule Only do
+        use Tesla, only: [:get]
+      end
+
+      defmodule Except do
+        use Tesla.Builder, except: ~w(delete)a
+      end
     end
+
+    @http_verbs ~w(head get delete trace options post put patch)a
 
     test "middleware list" do
       assert Mc.Basic.__middleware__ == [
@@ -58,6 +68,18 @@ defmodule TeslaTest do
 
     test "adapter as function" do
       assert is_function(Mc.Fun.__adapter__)
+    end
+
+    test "limit generated functions (only)" do
+      functions = Mc.Only.__info__(:functions) |> Keyword.keys() |> Enum.uniq
+      assert :get in functions
+      refute Enum.any?(@http_verbs -- [:get], &(&1 in functions))
+    end
+
+    test "limit generated functions (except)" do
+      functions = Mc.Except.__info__(:functions) |> Keyword.keys() |> Enum.uniq
+      refute :delete in functions
+      assert Enum.all?(@http_verbs -- [:delete], &(&1 in functions))
     end
   end
 


### PR DESCRIPTION
Hello,

I added some configuration options for `use Tesla` and `use Tesla.Builder`
- :only and :except - limit generated functions
```
#usage
use Tesla, only: [:get, :post]
use Tesla, only: ~w(delete)a
use Tesla, except: [:get, :post]
use Tesla, except: ~w(delete)a
```
- :docs - disable generating docs, useful when you create package based on Tesla, but don't want docs for it contains docs for all get, post, put etc. functions generated by Tesla
```
defmodule MyProject.Module do
  use Tesla, docs: false

  @doc "custom function"
  def custom_function: get("something")
end
```