### PR TITLE
Fix warnings in FollowRedirects middleware

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -19,7 +19,7 @@ defmodule Tesla.Middleware.FollowRedirects do
     redirect(env, next, max)
   end
 
-  defp redirect(env, next, left) when left <= 0 do
+  defp redirect(_env, _next, left) when left <= 0 do
     raise Tesla.Error, "too many redirects"
   end
 


### PR DESCRIPTION
Elixir was complaining about `env` and `next` being unused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teamon/tesla/54)
<!-- Reviewable:end -->
