### PR TITLE
Pass options from env to ibrowse adapter

### DIFF
--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -15,7 +15,7 @@ if Code.ensure_loaded?(:ibrowse) do
         Enum.into(env.headers, []),
         env.method,
         body,
-        opts
+        opts ++ env.opts
       )
     end
 


### PR DESCRIPTION
It looks like this is already possible when using the `hackney` or `httpc` adapter, but not for `ibrowse`.