### PR TITLE
Fix calculation of request-response cycle duration in Logger middleware

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -8,7 +8,7 @@ defmodule Tesla.Middleware.Logger do
   end
 
   defp log(env, time) do
-    ms = :io_lib.format("~.3f", [time / 10000])
+    ms = :io_lib.format("~.3f", [time / 1000])
     method = env.method |> to_string |> String.upcase
     message = "#{method} #{env.url} -> #{env.status} (#{ms} ms)"
 


### PR DESCRIPTION
`:timer.tc/2` returns elapsed time in *microseconds* and this value should be
divided by 1000 to get time in *milliseconds*.

See http://erlang.org/doc/man/timer.html#tc-2