### PR TITLE
Add Basic Auth middleware

### DIFF
--- a/lib/tesla/middleware/basic_auth.ex
+++ b/lib/tesla/middleware/basic_auth.ex
@@ -1,0 +1,52 @@
+defmodule Tesla.Middleware.BasicAuth do
+  @moduledoc """
+  Basic authentication middleware
+
+  [Wiki on the topic](https://en.wikipedia.org/wiki/Basic_access_authentication)
+
+  Example:
+      defmodule MyClient do
+        use Tesla
+
+        def client(username, password, opts \\ %{}) do
+          Tesla.build_client [
+            {Tesla.Middleware.BasicAuth, Map.merge(%{username: username, password: password}, opts)}
+          ]
+        end
+      end
+
+  Options:
+  - `:username`  - username (defaults to `""`)
+  - `:password`  - password (defaults to `""`)
+  """
+
+  def call(env, next, opts) do
+    opts = opts || %{}
+
+    env
+    |> Map.update!(:headers, &Map.merge(&1, authorization_header(opts)))
+    |> Tesla.run(next)
+  end
+
+  defp authorization_header(opts) do
+    opts
+    |> authorization_vars()
+    |> encode()
+    |> create_header()
+  end
+
+  defp authorization_vars(opts) do
+    %{
+      username: opts[:username] || "",
+      password: opts[:password] || "",
+    }
+  end
+
+  defp create_header(auth) do
+    %{"Authorization" => "Basic #{auth}"}
+  end
+
+  defp encode(%{username: username, password: password}) do
+    Base.encode64("#{username}:#{password}")
+  end
+end

--- a/test/tesla/middleware/basic_auth_test.exs
+++ b/test/tesla/middleware/basic_auth_test.exs
@@ -1,0 +1,75 @@
+defmodule BasicAuthTest do
+  use ExUnit.Case, async: false
+
+  use Tesla.Middleware.TestCase, middleware: Tesla.Middleware.BasicAuth
+
+  defmodule BasicClient do
+    use Tesla
+
+    adapter fn env ->
+      case env.url do
+        "/basic-auth" -> env
+      end
+    end
+
+    def client(username, password, opts \\ %{}) do
+      Tesla.build_client [
+        {Tesla.Middleware.BasicAuth, Map.merge(%{
+          username: username,
+          password: password,
+        }, opts)}
+      ]
+    end
+
+    def client() do
+      Tesla.build_client [Tesla.Middleware.BasicAuth]
+    end
+  end
+
+  defmodule BasicClientPlugOptions do
+    use Tesla
+    plug Tesla.Middleware.BasicAuth, username: "Auth", password: "Test"
+
+    adapter fn env ->
+      case env.url do
+        "/basic-auth" -> env
+      end
+    end
+  end
+
+  test "sends request with proper authorization header" do
+    username = "Aladdin"
+    password = "OpenSesame"
+
+    base_64_encoded = Base.encode64("#{username}:#{password}")
+    assert base_64_encoded == "QWxhZGRpbjpPcGVuU2VzYW1l"
+
+    request = BasicClient.client(username, password) |> BasicClient.get("/basic-auth")
+    auth_header = request.headers["authorization"]
+
+    assert auth_header == "Basic #{base_64_encoded}"
+  end
+
+  test "it correctly encodes a blank username and password" do
+    base_64_encoded = Base.encode64(":")
+    assert base_64_encoded == "Og=="
+
+    request = BasicClient.client() |> BasicClient.get("/basic-auth")
+    auth_header = request.headers["authorization"]
+
+    assert auth_header == "Basic #{base_64_encoded}"
+  end
+
+  test "username and password can be passed to plug directly" do
+    username = "Auth"
+    password = "Test"
+
+    base_64_encoded = Base.encode64("#{username}:#{password}")
+    assert base_64_encoded == "QXV0aDpUZXN0"
+
+    request = BasicClientPlugOptions.get("/basic-auth")
+    auth_header = request.headers["authorization"]
+
+    assert auth_header == "Basic #{base_64_encoded}"
+  end
+end


### PR DESCRIPTION
Allow the generation Basic Authentication headers.
There was a request for this functionality on the Elixir Slack and it seemed like a fairly easy addition!
I've mostly just adapted the Digest Auth middleware and simplified it a bit.

Let me know if you'd like any modifications!