### PR TITLE
Start the :ssl application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Tesla.Mixfile do
   end
 
   def applications(:test), do: applications(:dev) ++ [:httparrot]
-  def applications(_), do: [:logger]
+  def applications(_), do: [:logger, :ssl]
 
   defp description do
     "HTTP client library, with support for middleware and multiple adapters."


### PR DESCRIPTION
Adds the `:ssl` application to the list of applications in `mix.exs`.

When using the default `httpc` adapter, attempting to GET an https URL would result in the error `** (Tesla.Error) adapter error: :econnrefused`.

The `:econnrefused` error is actually hiding the root cause, which is `:ssl_not_started`.

It appears that the httpc adapter is not automatically starting the `:ssl` application.

I tried to find a way to make a test fail, but was unable to.  I believe that something else that loads during the test run starts the `:ssl` application, causing all of the tests to pass.

I did run this version with my application and it now works as I expect.

Fixes #74 