### PR TITLE
Return error tuple instead of raising errors

### DIFF
--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -6,9 +6,7 @@ defmodule Tesla.Middleware.Normalize do
     |> normalize
   end
 
-  def normalize({:error, reason}) do
-    raise %Tesla.Error{message: "adapter error: #{inspect reason}", reason: reason}
-  end
+  def normalize({:error, reason}), do: {:error, reason}
   def normalize(env) do
     env
     |> Map.update!(:status,   &normalize_status/1)

--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -23,7 +23,7 @@ defmodule Tesla.Middleware.FollowRedirects do
       %{status: status} = env when not status in @redirect_statuses ->
         env
       _ ->
-        raise Tesla.Error, "too many redirects"
+        {:error, :too_many_redirects}
     end
   end
 

--- a/lib/tesla/middleware/fuse.ex
+++ b/lib/tesla/middleware/fuse.ex
@@ -42,12 +42,9 @@ if Code.ensure_loaded?(:fuse) do
     end
 
     defp run(env, next, name) do
-      try do
-        Tesla.run(env, next)
-      rescue
-        _error ->
-          :fuse.melt(name)
-          {:error, :unavailable}
+      with {:error, :econnrefused} <- Tesla.run(env, next) do
+        :fuse.melt(name)
+        {:error, :unavailable}
       end
     end
   end

--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -55,7 +55,6 @@ defmodule Tesla.Middleware.JSON do
 
   def decodable_body?({:error, _}), do: false
   def decodable_body?(env) do
-    env != {:error, _} ||
     (is_binary(env.body)  && env.body != "") ||
     (is_list(env.body)    && env.body != [])
   end

--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -70,8 +70,6 @@ defmodule Tesla.Middleware.JSON do
   defp process(data, op, opts) do
     with {:ok, value} <- do_process(data, op, opts) do
       value
-    else
-      {:error, reason} -> raise %Tesla.Error{message: "JSON #{op} error: #{inspect reason}", reason: reason}
     end
   end
 

--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -53,6 +53,7 @@ defmodule Tesla.Middleware.JSON do
 
   def decodable?(env, opts), do: decodable_body?(env) && decodable_content_type?(env, opts)
 
+  def decodable_body?({:error, _}), do: false
   def decodable_body?(env) do
     env != {:error, _} ||
     (is_binary(env.body)  && env.body != "") ||

--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -54,6 +54,7 @@ defmodule Tesla.Middleware.JSON do
   def decodable?(env, opts), do: decodable_body?(env) && decodable_content_type?(env, opts)
 
   def decodable_body?(env) do
+    env != {:error, _} ||
     (is_binary(env.body)  && env.body != "") ||
     (is_list(env.body)    && env.body != [])
   end

--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -32,15 +32,9 @@ defmodule Tesla.Middleware.Retry do
   end
 
   defp retry(env, next, delay, retries) do
-    Tesla.run(env, next)
-  rescue
-    error -> case error do
-      %Tesla.Error{} ->
-        :timer.sleep(delay)
-        retry(env, next, delay, retries - 1)
-
-      _ ->
-        reraise error, System.stacktrace
+    with {:error, :econnrefused} <- Tesla.run(env, next)
+    do   :timer.sleep(delay)
+         retry(env, next, delay, retries - 1)
     end
   end
 end

--- a/test/tesla/adapter/test_case.ex
+++ b/test/tesla/adapter/test_case.ex
@@ -69,9 +69,7 @@ defmodule Tesla.Adapter.TestCase.Basic do
       end
 
       test "error: connection refused" do
-        assert_raise Tesla.Error, fn ->
-          response = B.Client.get("http://localhost:1234")
-        end
+        assert {:error, :econnrefused} = B.Client.get("http://localhost:1234")
       end
 
       test "autoredirects disabled by default" do

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -25,8 +25,8 @@ defmodule FollowRedirectsTest do
     assert Client.get("/5").status == 200
   end
 
-  test "raise error when redirect default max redirects is exceeded" do
-    assert_raise(Tesla.Error, "too many redirects", fn-> Client.get("/6") end)
+  test "error when redirect default max redirects is exceeded" do
+    assert {:error, :too_many_redirects} = Client.get("/6")
   end
 
   defmodule CustomMaxRedirectsClient do
@@ -53,8 +53,8 @@ defmodule FollowRedirectsTest do
     assert CMRClient.get("/1").status == 200
   end
 
-  test "raise error when custom max redirects is exceeded" do
-    assert_raise(Tesla.Error, "too many redirects", fn-> CMRClient.get("/2") end)
+  test "error when custom max redirects is exceeded" do
+    assert {:error, :too_many_redirects} = CMRClient.get("/2")
   end
 
 end

--- a/test/tesla/middleware/retry_test.exs
+++ b/test/tesla/middleware/retry_test.exs
@@ -42,8 +42,8 @@ defmodule RetryTest do
     assert %Tesla.Env{url: "/maybe", method: :get} = Client.get("/maybe")
   end
 
-  test "raise if max_retries is exceeded" do
-    assert_raise Tesla.Error, fn -> Client.get("/nope") end
+  test "error if max_retries is exceeded" do
+    {:error, :econnrefused} = Client.get("/nope")
   end
 
 end


### PR DESCRIPTION
I found I have to write extra code to handle the raises. This way the
user gets to choose whether to raise.

When googling around, noticed it was also brought up here:
https://elixirforum.com/t/error-handling-with-tesla/4511/4