### PR TITLE
allow json decoding to be used with middleware that transforms errors

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -53,6 +53,7 @@ defmodule Tesla.Middleware.JSON do
 
   def decodable?(env, opts), do: decodable_body?(env) && decodable_content_type?(env, opts)
 
+  def decodable_body?({:error, _}), do: false 
   def decodable_body?(env) do
     (is_binary(env.body)  && env.body != "") ||
     (is_list(env.body)    && env.body != [])


### PR DESCRIPTION
Using the middleware to handle error raises/tuples along with using json middleware gives this:

** (UndefinedFunctionError) function :error.body/1 is undefined (module :error is not available)
                :error.body({:error, :econnrefused})
        (tesla) lib/tesla/middleware/json.ex:57: Tesla.Middleware.JSON.decodable_body?/1
        

But adding this line handles that case. 