### PR TITLE
safely pass down empty options

### DIFF
--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -14,7 +14,7 @@ if Code.ensure_loaded?(:hackney) do
         Tesla.build_url(env.url, env.query),
         Enum.into(env.headers, []),
         env.body,
-        opts ++ env.opts
+        (opts ++ List.wrap(env.opts))
       )
     end
     defp request(method, url, headers, %Stream{} = body, opts), do: request_stream(method, url, headers, body, opts)

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -32,7 +32,7 @@ defmodule Tesla.Adapter.Httpc do
       Enum.into(env.headers, [], fn {k,v} -> {to_charlist(k), to_charlist(v)} end),
       content_type,
       env.body,
-      Keyword.split(opts ++ env.opts, @http_opts)
+      Keyword.split(opts ++ List.wrap(env.opts), @http_opts)
     )
   end
 

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -17,7 +17,7 @@ if Code.ensure_loaded?(:ibrowse) do
         Enum.into(env.headers, []),
         env.method,
         body,
-        opts ++ env.opts
+        opts ++ List.wrap(env.opts)
       )
     end
 

--- a/test/tesla/adapter/test_case.ex
+++ b/test/tesla/adapter/test_case.ex
@@ -40,6 +40,11 @@ defmodule Tesla.Adapter.TestCase.Basic do
         assert Regex.match?(~r/some-post-data/, response.body)
       end
 
+      test "basic get request with nil opts" do
+        response = B.Client.get("#{http_url()}/ip", opts: nil)
+        assert response.status == 200
+      end
+
       test "unicode request" do
         response = B.Client.post("#{http_url()}/post", "1 ø 2 đ 1 \u00F8 2 \u0111", headers: %{"Content-Type" => "text/plain"})
         assert response.status == 200


### PR DESCRIPTION
in case `env.opts` is nil the appending passes down `nil` (`[] ++ nil` evaluates to `nil`)