### PR TITLE
Fix absolute URL redirects

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -37,12 +37,12 @@ defmodule Tesla.Middleware.FollowRedirects do
     end
   end
 
-  defp parse_location("/" <> rest = location, env) do
-    if String.ends_with?(env.url, "/") do
-      env.url <> rest
-    else
-      env.url <> location
-    end
+  defp parse_location("/" <> _rest = location, env) do
+    env.url
+    |> URI.parse
+    |> URI.merge(location)
+    |> URI.to_string
   end
+
   defp parse_location(location, _env), do: location
 end

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -72,6 +72,8 @@ defmodule FollowRedirectsTest do
           {301, %{'Location' => '/pl'}, ""}
         "https://example.com/" ->
           {301, %{'Location' => '/pl'}, ""}
+        "https://example.com/article" ->
+          {301, %{'Location' => '/pl'}, ""}
       end
 
       %{env | status: status, headers: headers, body: body}
@@ -86,5 +88,9 @@ defmodule FollowRedirectsTest do
 
   test "doesn't create double slashes inside new url" do
     assert RLClient.get("https://example.com/").url == "https://example.com/pl"
+  end
+
+  test "rewrites URLs to their root" do
+    assert RLClient.get("https://example.com/article").url == "https://example.com/pl"
   end
 end


### PR DESCRIPTION
The URL wasn't parsed correctly causing a relative path that starts with a "/" to be appended to the entire URL. 

The following URL `http://foo.com/hello` generates the following header `Location: "/world"`, appending "/world" to the entire URL creating `http://foo.com/hello/world`. It should be `http://foo.com/word`.
