### PR TITLE
Introduce Tesla.Client with pre/post middleware

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -476,7 +476,7 @@ defmodule Tesla do
   end
 
   def build_adapter(fun) do
-    %Tesla.Client{fun: fn env, _next -> fun.(env) end}
+    %Tesla.Client{post: [{:fn, fn env, _next -> fun.(env) end}]}
   end
 
   def build_url(url, []), do: url

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -439,8 +439,11 @@ defmodule Tesla do
 
 
   def default_adapter do
-    adapter = Application.get_env(:tesla, :adapter, :httpc) |> Tesla.alias
-    {adapter, []}
+    Application.get_env(:tesla, :adapter, :httpc) |> Tesla.alias
+  end
+
+  def run_default_adapter(env, opts \\ []) do
+    apply(default_adapter(), :call, [env, opts])
   end
 
   def default_middleware do


### PR DESCRIPTION
This change is backward compatible:
- Tesla.build_client API stays the same
- one can still use simple function as a client

Tesla.Client struct can hold any custom `fun` (as before)
but can now hold `pre` and `post` middleware lists.
`pre` works the same way as one given to `build_client`.
`post` middleware is injected right before adapter.
It can be used as a regular middleware but can be also
used to dynamically override adapter in runtime.
This is mostly useful in testing:


```ex
defmodule MyAPI do
  use Tesla

  def help(client \\ %Tesla.Client{}) do
    get(client, "/help")
  end
end

client = Tesla.build_adapter fn env ->
  %{env | status: 200, body: "new body"}
end

assert %{body: "new body"} = MyAPI.get(client)
```