### PR TITLE
Introducing Tesla.Mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 /doc
 /cover
 .tool-versions
+/sandbox

--- a/README.md
+++ b/README.md
@@ -144,23 +144,40 @@ To use it simply include `adapter :ibrowse` line in your API client definition.
 NOTE: Remember to include ibrowse in applications list.
 
 
-### Test / Mock
+### Testing
 
-When testing it might be useful to use simple function as adapter:
+You can set the adapter to `:mock` in tests.
 
 ```elixir
-defmodule MyApi do
-  use Tesla
+# config/test.exs
+config :tesla, adapter: :mock
+```
 
-  adapter fn (env) ->
-    case env.url do
-      "/"       -> %{env | status: 200, body: "home"}
-      "/about"  -> %{env | status: 200, body: "about us"}
+Then, mock requests before using your client:
+
+
+```elixir
+defmodule MyAppTest do
+  use ExUnit.Case
+
+  setup do
+    Tesla.Mock.mock fn
+      %{method: :get, url: "http://example.com/hello"} ->
+        %Tesla.Env{status: 200, body: "hello"}
+      %{method: :post, url: "http://example.com/world"} ->
+        %Tesla.Env{status: 200, body: "hi!"}
     end
+
+    :ok
+  end
+
+  test "list things" do
+    assert %Tesla.Env{} = env = MyApp.get("/hello")
+    assert env.status == 200
+    assert env.body == "hello"
   end
 end
 ```
-
 
 ## Middleware
 

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -380,6 +380,7 @@ defmodule Tesla do
     httpc:    Tesla.Adapter.Httpc,
     hackney:  Tesla.Adapter.Hackney,
     ibrowse:  Tesla.Adapter.Ibrowse,
+    mock:     Tesla.Mock,
 
     base_url:     Tesla.Middleware.BaseUrl,
     headers:      Tesla.Middleware.Headers,

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -1,0 +1,114 @@
+defmodule Tesla.Mock do
+  @moduledoc """
+  Mock adapter for better testing.
+
+  ### Setup
+
+      # config/test.exs
+      config :tesla, adapter: :mock
+
+  ### Example test
+
+      defmodule MyAppTest do
+        use ExUnit.Case
+
+        setup do
+          Tesla.Mock.mock fn
+            %{method: :get} ->
+              %Tesla.Env{status: 200, body: "hello"}
+          end
+
+          :ok
+        end
+
+        test "list things" do
+          assert %Tesla.Env{} = env = MyApp.get("...")
+          assert env.status == 200
+          assert env.body == "hello"
+        end
+      end
+
+  """
+
+  defmodule Error do
+    defexception env: nil, ex: nil, stacktrace: []
+
+    def message(%__MODULE__{ex: nil}) do
+      """
+      There is no mock set for process #{inspect(self())}.
+      Use Tesla.Mock.mock/1 to mock HTTP requests.
+
+      See https://github.com/teamon/tesla#testing
+      """
+    end
+
+    def message(%__MODULE__{env: env, ex: %FunctionClauseError{} = ex, stacktrace: stacktrace}) do
+      """
+      Request not mocked
+
+      The following request was not mocked:
+
+      #{inspect(env, pretty: true)}
+
+      #{Exception.format(:error, ex, stacktrace)}
+      """
+    end
+  end
+
+  ## PUBLIC API
+
+  @doc """
+  Setup mocks for current test.
+
+  ## Examples
+
+      # Match on method & url and return whole Tesla.Env
+      Tesla.Mock.mock fn
+        %{method: :get,  url: "http://example.com/list"} ->
+          %Tesla.Env{status: 200, body: "hello"}
+      end
+
+      # You can use any logic required
+      Tesla.Mock.mock fn env ->
+        case env.url do
+          "http://example.com/list" ->
+            %Tesla.Env{status: 200, body: "ok!"}
+          _ ->
+            %Tesla.Env{status: 404, body: "NotFound"}
+      end
+
+      # mock will also accept short version of response
+      # in the form of {status, headers, body}
+      Tesla.Mock.mock fn
+        %{method: :post} -> {201, %{}, %{id: 42}}
+      end
+  """
+  @spec mock((Tesla.Env.t -> Tesla.Env.t | {integer, map, any})) :: no_return
+  def mock(fun) when is_function(fun) do
+    Process.put(__MODULE__, fun)
+  end
+
+
+  ## ADAPTER IMPLEMENTATION
+
+  def call(env, _opts) do
+    case Process.get(__MODULE__) do
+      nil ->
+        raise Tesla.Mock.Error, env: env
+      fun ->
+        case rescue_call(fun, env) do
+          {status, headers, body} ->
+            %{env | status: status, headers: headers, body: body}
+          %Tesla.Env{} = env ->
+            env
+        end
+    end
+  end
+
+  defp rescue_call(fun, env) do
+    fun.(env)
+  rescue
+    ex in FunctionClauseError ->
+      raise Tesla.Mock.Error, env: env, ex: ex, stacktrace: System.stacktrace()
+  end
+end

--- a/test/tesla/mock_test.exs
+++ b/test/tesla/mock_test.exs
@@ -1,0 +1,51 @@
+defmodule Tesla.MockTest do
+  use ExUnit.Case
+
+  setup do
+    Application.put_env(:tesla, :adapter, :mock)
+
+    Tesla.Mock.mock fn
+      %{method: :get,  url: "http://example.com/list"}   -> %Tesla.Env{status: 200, body: "hello"}
+      %{method: :post, url: "http://example.com/create"} -> {201, %{}, %{id: 42}}
+    end
+
+    :ok
+  end
+
+  defmodule Client do
+    use Tesla
+
+    plug Tesla.Middleware.BaseUrl, "http://example.com"
+    plug Tesla.Middleware.JSON
+
+    def list do
+      get("/list")
+    end
+
+    def search() do
+      get("/search")
+    end
+
+    def create(data) do
+      post("/create", data)
+    end
+  end
+
+  test "mock get request" do
+    assert %Tesla.Env{} = env = Client.list()
+    assert env.status == 200
+    assert env.body == "hello"
+  end
+
+  test "raise on unmocked request" do
+    assert_raise Tesla.Mock.Error, fn ->
+      Client.search()
+    end
+  end
+
+  test "mock post request" do
+    assert %Tesla.Env{} = env = Client.create(%{"some" => "data"})
+    assert env.status == 201
+    assert env.body.id == 42
+  end
+end

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -374,4 +374,42 @@ defmodule TeslaTest do
       end
     end
   end
+
+  describe "Adapter from config" do
+    defmodule C do
+      defmodule A do
+        use Tesla
+      end
+
+      defmodule B do
+        use Tesla
+        adapter :custom
+      end
+    end
+
+    setup do
+      # clean config
+      Application.delete_env(:tesla, C.A)
+      Application.delete_env(:tesla, C.B)
+      :ok
+    end
+
+    test "use default adapter" do
+      assert C.A.__adapter__ == Tesla.default_adapter
+    end
+
+    test "use module-set adapter" do
+      assert C.B.__adapter__ == {:custom, nil}
+    end
+
+    test "use adapter override from config" do
+      Application.put_env(:tesla, C.A, adapter: :mock)
+      assert C.A.__adapter__ == Tesla.Mock
+    end
+
+    test "prefer config over module setting" do
+      Application.put_env(:tesla, C.B, adapter: :mock)
+      assert C.B.__adapter__ == Tesla.Mock
+    end
+  end
 end


### PR DESCRIPTION
@amatalai, @hodak please take a look if you have a minute and let me know what do you think.

While this is working, I'm not sure how to handle adapter configuration:
- The default behaviour is to check client, then module (`adapter :hackney` in client module), then `config :tesla, :adapter` and then fallback to `Tesla.default_adapter`
- In test, it would be useful to override all setting and force mock adapter.