### PR TITLE
handle multiparts when file path is invalid

### DIFF
--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -46,6 +46,9 @@ if Code.ensure_loaded?(:hackney) do
     end
     defp request(method, url, headers, %Stream{} = body, opts), do: request_stream(method, url, headers, body, opts)
     defp request(method, url, headers, body, opts) when is_function(body), do: request_stream(method, url, headers, body, opts)
+    defp request(_method, _url, _headers, %Multipart{valid: false}, _opts) do
+      raise Tesla.Error, "could not stream non-existent files"
+    end
     defp request(method, url, headers, %Multipart{} = mp, opts) do
       headers = headers ++ Multipart.headers(mp)
       body = Multipart.body(mp)

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -43,6 +43,9 @@ defmodule Tesla.Adapter.Httpc do
     :httpc.request(method, {url, headers}, http_opts, opts)
   end
 
+  defp request(_method, _url, _headers, _content_type, %Multipart{valid: false}, _opts) do
+    raise Tesla.Error, "could not stream non-existent files"
+  end
   defp request(method, url, headers, _content_type, %Multipart{} = mp, opts) do
     headers = headers ++ Multipart.headers(mp)
     headers = for {key, value} <- headers, do: {to_charlist(key), to_charlist(value)}

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -47,6 +47,9 @@ if Code.ensure_loaded?(:ibrowse) do
       )
     end
 
+    defp request(_url, _headers, _method, %Multipart{valid: false}, _opts) do
+      raise Tesla.Error, "could not stream non-existent files"
+    end
     defp request(url, headers, method, %Multipart{} = mp, opts) do
       headers = headers ++ Multipart.headers(mp)
       body = stream_to_fun(Multipart.body(mp))

--- a/test/support/adapter_case/multipart.ex
+++ b/test/support/adapter_case/multipart.ex
@@ -34,6 +34,21 @@ defmodule Tesla.AdapterCase.Multipart do
             "foobar" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"
           }
         end
+
+        test "POST invalid multipart" do
+          mp = Multipart.new
+          |> Multipart.add_file("test/tesla/invalid")
+
+          request = %Env{
+            method: :post,
+            url: "#{@url}/post",
+            body: mp
+          }
+
+          assert_raise Tesla.Error, "could not stream non-existent files", fn ->
+            call(request)
+          end
+        end
       end
     end
   end

--- a/test/tesla/multipart_test.exs
+++ b/test/tesla/multipart_test.exs
@@ -159,4 +159,23 @@ echo "test multipart file"
 --#{mp.boundary}--\r
 """
   end
+
+  test "add_file (file doesn't exist)" do
+    mp =
+      Multipart.new
+      |> Multipart.add_file("test/tesla/invalid")
+
+    refute mp.valid
+  end
+
+  test "add_file! (file exist)" do
+    assert Multipart.new |> Multipart.add_file!("test/tesla/multipart_test_file.sh")
+  end
+
+  test "add_file! (file doesn't exist)" do
+    assert_raise Tesla.Error, "file test/tesla/invalid doesn't exist", fn ->
+      Multipart.new
+      |> Multipart.add_file!("test/tesla/invalid")
+    end
+  end
 end


### PR DESCRIPTION
This should fix situation when invalid filepath is given to `Multipart.add_file` and then request is made.

In such cases different adapters behave differently. `:httpc` hangs and other two raise errors.

My proposal is to:
* add `Multipart.add_file!` (bang version) which raises Tesla.Error immediately
* let `Multipart.add_file` mark multipart struct as invalid
* let user handle invalid multipart on its own
* raise Tesla.Error on request with invalid multipart