### PR TITLE
Add Multipart.add_file_content function

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ mp =
   |> Multipart.add_field("field2", "bar", headers: [{:"Content-Id", 1}, {:"Content-Type", "text/plain"}])
   |> Multipart.add_file("test/tesla/multipart_test_file.sh")
   |> Multipart.add_file("test/tesla/multipart_test_file.sh", name: "foobar")
+  |> Multipart.add_file_content("sample file content", "sample.txt")
 
 response = MyApiClient.post("http://httpbin.org/post", mp)
 ```


### PR DESCRIPTION
Extend Multipart module with `add_file_content` function.

This allow us to pass a file content data, compared to `Multipart.add_file` where you must have a file on the FS.

Tipical use case: the file content data is retrieved from an external source (ex: DB, cache, ..) or is just in memory.