### PR TITLE
Add warning that the shown README is not for the released version but for master

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 Tesla is an HTTP client loosely based on [Faraday](https://github.com/lostisland/faraday).
 It embraces the concept of middleware when processing the request/response cycle.
 
+Note that this README refers to the `master` branch of Tesla, not the latest
+released version on Hex. See [the documentation](http://hexdocs.pm/tesla) for
+the documentation of the version you're using.
+
 ## HTTP Client example
 
 Define module with `use Tesla` and choose from a variety of middleware.


### PR DESCRIPTION
This bit me when I was trying to add tests, was scratching my head on why Tesla.Mock was not found.