### PR TITLE
Don't kill parent process when timeout occurs

### DIFF
--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -34,7 +34,12 @@ defmodule Tesla.Middleware.Timeout do
       |> Task.await(timeout)
       |> repass_error
     catch :exit, {:timeout, _} ->
-      Process.exit(task.pid, :kill)
+      if Version.match?(System.version(), ">= 1.4.0") do
+        Task.shutdown(task, 0)
+      else
+        task.pid |> Process.unlink()
+        task.pid |> Process.exit(:kill)
+      end
       raise @timeout_error
     end
   end


### PR DESCRIPTION
Killing the caller because of a timeout is not what people want to do.