### PR TITLE
Make Tesla.Mock work outside the test process scope

### DIFF
--- a/test/tesla/mock_test.exs
+++ b/test/tesla/mock_test.exs
@@ -43,6 +43,13 @@ defmodule Tesla.MockTest do
       assert env.body == "hello"
     end
 
+    test "mock request from spawned process" do
+      pid = self()
+      spawn fn -> send pid, Client.list() end
+
+      assert_receive %Tesla.Env{status: 200, body: "hello"}
+    end
+
     test "raise on unmocked request" do
       assert_raise Tesla.Mock.Error, fn ->
         Client.search()


### PR DESCRIPTION
The current implementation of `Tesla.Mock` mocks only requests initiated from the test process.
This leads to `Tesla.Mock.mock/1` not being suitable for `setup_all` callbacks or API client modules which perform the requests from within spawned processes.

This PR aims to solve the aforementioned shortcomings in a backwards compatible manner.