### PR TITLE
Global mock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,10 @@ You can set the adapter to `:mock` in tests.
 
 ```elixir
 # config/test.exs
+# Use mock adapter for all clients
 config :tesla, adapter: :mock
+# or only for one
+config :tesla, MyClient, adapter: :mock
 ```
 
 Then, mock requests before using your client:

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,4 +17,6 @@ if Mix.env == :test do
   config :sasl,
     errlog_type: :error,
     sasl_error_logger: false
+
+  config :tesla, MockClient, adapter: :mock
 end

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -57,6 +57,38 @@ defmodule Tesla.Mock do
     %{method: :post} -> {201, %{}, %{id: 42}}
   end
   ```
+
+  ### Global mocks
+  By default, mocks are bound to the current process,
+  i.e. the process running a single test case.
+  This design allows proper isolation between test cases
+  and make testing in parallel (`async: true`) possible.
+
+  While this style is recommended, there is one drawback:
+  if Tesla client is called from different process then the
+  test case it will not get proper mock.
+
+  To solve this issue it is possible to setup a global mock
+  using `mock_global/1` function.
+
+  ```
+  defmodule MyTest do
+    use ExUnit.Case, async: false # must be false!
+
+    setup_all do
+      Tesla.Mock.mock_global fn
+        env -> # ...
+      end
+
+      :ok
+    end
+
+    # ...
+  end
+  ```
+
+  **WARNING**: Using global mocks may affect tests with local mock
+  (because of fallback to global mock in case local one is not found)
   """
 
   defmodule Error do
@@ -88,30 +120,47 @@ defmodule Tesla.Mock do
 
   @doc """
   Setup mocks for current test.
+
+  This mock will only be available to the current process.
   """
   @spec mock((Tesla.Env.t -> Tesla.Env.t | {integer, map, any})) :: no_return
-  def mock(fun) when is_function(fun) do
-    Process.put(__MODULE__, fun)
-    Agent.start_link(fn -> fun end, name: :__tesla_mock__)
-  end
+  def mock(fun) when is_function(fun), do: pdict_set(fun)
+
+  @doc """
+  Setup global mocks.
+
+  **WARNING**: This mock will be available to ALL process.
+  It might cause conflicts when running tests in parallel!
+  """
+  @spec mock_global((Tesla.Env.t -> Tesla.Env.t | {integer, map, any})) :: no_return
+  def mock_global(fun) when is_function(fun), do: agent_set(fun)
+
 
 
   ## ADAPTER IMPLEMENTATION
 
   def call(env, _opts) do
-    case {Process.get(__MODULE__), Process.whereis(:__tesla_mock__)} do
-      {fun, _pid} when is_function(fun) -> mock_call(fun, env)
-      {nil, pid} when is_pid(pid) -> Agent.get(pid, &(mock_call(&1, env)))
-      _ -> raise Tesla.Mock.Error, env: env
+    case pdict_get() || agent_get() do
+      nil ->
+        raise Tesla.Mock.Error, env: env
+      fun ->
+        case rescue_call(fun, env) do
+          {status, headers, body} ->
+            %{env | status: status, headers: headers, body: body}
+          %Tesla.Env{} = env ->
+            env
+        end
     end
   end
 
-  defp mock_call(fun, env) do
-    case rescue_call(fun, env) do
-      {status, headers, body} ->
-        %{env | status: status, headers: headers, body: body}
-      %Tesla.Env{} = env ->
-        env
+  defp pdict_set(fun), do: Process.put(__MODULE__, fun)
+  defp pdict_get, do: Process.get(__MODULE__)
+
+  defp agent_set(fun), do: {:ok, _pid} = Agent.start_link(fn -> fun end, name: __MODULE__)
+  defp agent_get do
+    case Process.whereis(__MODULE__) do
+      nil -> nil
+      pid -> Agent.get(pid, fn f -> f end)
     end
   end
 

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -65,8 +65,8 @@ defmodule Tesla.Mock do
   and make testing in parallel (`async: true`) possible.
 
   While this style is recommended, there is one drawback:
-  if Tesla client is called from different process then the
-  test case it will not get proper mock.
+  if Tesla client is called from different process
+  it will not use the setup mock.
 
   To solve this issue it is possible to setup a global mock
   using `mock_global/1` function.
@@ -129,7 +129,7 @@ defmodule Tesla.Mock do
   @doc """
   Setup global mocks.
 
-  **WARNING**: This mock will be available to ALL process.
+  **WARNING**: This mock will be available to ALL processes.
   It might cause conflicts when running tests in parallel!
   """
   @spec mock_global((Tesla.Env.t -> Tesla.Env.t | {integer, map, any})) :: no_return

--- a/test/support/mock_client.ex
+++ b/test/support/mock_client.ex
@@ -1,0 +1,18 @@
+defmodule MockClient do
+  use Tesla
+
+  plug Tesla.Middleware.BaseUrl, "http://example.com"
+  plug Tesla.Middleware.JSON
+
+  def list do
+    get("/list")
+  end
+
+  def search() do
+    get("/search")
+  end
+
+  def create(data) do
+    post("/create", data)
+  end
+end

--- a/test/tesla/global_mock_test.exs
+++ b/test/tesla/global_mock_test.exs
@@ -1,0 +1,19 @@
+defmodule Tesla.GlobalMockTest do
+  use ExUnit.Case, async: false
+
+  setup_all do
+    Tesla.Mock.mock_global fn
+      %{method: :get,  url: "http://example.com/list"}   -> %Tesla.Env{status: 200, body: "hello"}
+      %{method: :post, url: "http://example.com/create"} -> {201, %{}, %{id: 42}}
+    end
+
+    :ok
+  end
+
+  test "mock request from spawned process" do
+    pid = self()
+    spawn fn -> send pid, MockClient.list() end
+
+    assert_receive %Tesla.Env{status: 200, body: "hello"}
+  end
+end

--- a/test/tesla/mock/global_a_test.exs
+++ b/test/tesla/mock/global_a_test.exs
@@ -1,0 +1,16 @@
+defmodule Tesla.Mock.GlobalATest do
+  use ExUnit.Case, async: false
+
+  setup_all do
+    Tesla.Mock.mock_global fn
+      _env -> %Tesla.Env{status: 200, body: "AAA"}
+    end
+
+    :ok
+  end
+
+  test "mock get request" do
+    assert %Tesla.Env{} = env = MockClient.get("/")
+    assert env.body == "AAA"
+  end
+end

--- a/test/tesla/mock/global_b_test.exs
+++ b/test/tesla/mock/global_b_test.exs
@@ -1,0 +1,16 @@
+defmodule Tesla.Mock.GlobalBTest do
+  use ExUnit.Case, async: false
+
+  setup_all do
+    Tesla.Mock.mock_global fn
+      _env -> %Tesla.Env{status: 200, body: "BBB"}
+    end
+
+    :ok
+  end
+
+  test "mock get request" do
+    assert %Tesla.Env{} = env = MockClient.get("/")
+    assert env.body == "BBB"
+  end
+end

--- a/test/tesla/mock/local_a_test.exs
+++ b/test/tesla/mock/local_a_test.exs
@@ -1,0 +1,16 @@
+defmodule Tesla.Mock.LocalATest do
+  use ExUnit.Case, async: true
+
+  setup do
+    Tesla.Mock.mock fn
+      _env -> %Tesla.Env{status: 200, body: "AAA"}
+    end
+
+    :ok
+  end
+
+  test "mock get request" do
+    assert %Tesla.Env{} = env = MockClient.get("/")
+    assert env.body == "AAA"
+  end
+end

--- a/test/tesla/mock/local_b_test.exs
+++ b/test/tesla/mock/local_b_test.exs
@@ -1,0 +1,16 @@
+defmodule Tesla.Mock.LocalBTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    Tesla.Mock.mock fn
+      _env -> %Tesla.Env{status: 200, body: "BBB"}
+    end
+
+    :ok
+  end
+
+  test "mock get request" do
+    assert %Tesla.Env{} = env = MockClient.get("/")
+    assert env.body == "BBB"
+  end
+end

--- a/test/tesla/mock_test.exs
+++ b/test/tesla/mock_test.exs
@@ -43,6 +43,13 @@ defmodule Tesla.MockTest do
       assert env.body == "hello"
     end
 
+    test "mock request from spawned process" do
+      pid = self()
+      spawn fn -> send pid, Client.list() end
+
+      assert_receive %Tesla.Env{status: 200, body: "hello"}
+    end
+
     test "raise on unmocked request" do
       assert_raise Tesla.Mock.Error, fn ->
         Client.search()

--- a/test/tesla/mock_test.exs
+++ b/test/tesla/mock_test.exs
@@ -1,11 +1,6 @@
 defmodule Tesla.MockTest do
   use ExUnit.Case
 
-  defp setup_config(_) do
-    Application.put_env(:tesla, :adapter, :mock)
-    :ok
-  end
-
   defp setup_mock(_) do
     Tesla.Mock.mock fn
       %{method: :get,  url: "http://example.com/list"}   -> %Tesla.Env{status: 200, body: "hello"}
@@ -15,60 +10,32 @@ defmodule Tesla.MockTest do
     :ok
   end
 
-  defmodule Client do
-    use Tesla
-
-    plug Tesla.Middleware.BaseUrl, "http://example.com"
-    plug Tesla.Middleware.JSON
-
-    def list do
-      get("/list")
-    end
-
-    def search() do
-      get("/search")
-    end
-
-    def create(data) do
-      post("/create", data)
-    end
-  end
-
   describe "with mock" do
-    setup [:setup_config, :setup_mock]
+    setup :setup_mock
 
     test "mock get request" do
-      assert %Tesla.Env{} = env = Client.list()
+      assert %Tesla.Env{} = env = MockClient.list()
       assert env.status == 200
       assert env.body == "hello"
     end
 
-    test "mock request from spawned process" do
-      pid = self()
-      spawn fn -> send pid, Client.list() end
-
-      assert_receive %Tesla.Env{status: 200, body: "hello"}
-    end
-
     test "raise on unmocked request" do
       assert_raise Tesla.Mock.Error, fn ->
-        Client.search()
+        MockClient.search()
       end
     end
 
     test "mock post request" do
-      assert %Tesla.Env{} = env = Client.create(%{"some" => "data"})
+      assert %Tesla.Env{} = env = MockClient.create(%{"some" => "data"})
       assert env.status == 201
       assert env.body.id == 42
     end
   end
 
   describe "without mock" do
-    setup [:setup_config]
-
     test "raise on unmocked request" do
       assert_raise Tesla.Mock.Error, fn ->
-        Client.search()
+        MockClient.search()
       end
     end
   end


### PR DESCRIPTION
Continuation of #136, also related to #140

I've moved setting up global mock into separate function to be explicit about it. It will also fail fast when used inappropriately with async test cases.

@Zorbash, @amatalai please take a look.

@gottfrois, @pawelduda, @Daniel-Xu please try using tesla from `global-mock` branch and let us know if there are any issues.

```elixir
{:tesla, github: "teamon/tesla", branch: "global-mock"}
```