### PR TITLE
Improve Tesla.Mock test with JSON middleware

### DIFF
--- a/test/tesla/mock_test.exs
+++ b/test/tesla/mock_test.exs
@@ -4,7 +4,7 @@ defmodule Tesla.MockTest do
   defp setup_mock(_) do
     Tesla.Mock.mock(fn
       %{method: :get, url: "http://example.com/list"} -> %Tesla.Env{status: 200, body: "hello"}
-      %{method: :post, url: "http://example.com/create"} -> {201, %{}, %{id: 42}}
+      %{method: :post, url: "http://example.com/create", body: ~s({"some":"data"})} -> {201, %{"Content-Type" => "application/json"}, ~s({"id":42})}
     end)
 
     :ok
@@ -28,7 +28,7 @@ defmodule Tesla.MockTest do
     test "mock post request" do
       assert %Tesla.Env{} = env = MockClient.create(%{"some" => "data"})
       assert env.status == 201
-      assert env.body.id == 42
+      assert env.body == %{"id" => 42}
     end
   end
 


### PR DESCRIPTION
I think this is more specific (and clear) given that `MockClient` plugs in `Tesla.Middleware.JSON`.
