### PR TITLE
Export macro formatting in .formatter.exs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,13 +1,17 @@
+# Used by "mix format" and to export configuration.
+export_locals_without_parens = [
+  plug: 1,
+  plug: 2,
+  adapter: 1,
+  adapter: 2
+]
+
 [
   inputs: [
     "lib/**/*.{ex,exs}",
     "test/**/*.{ex,exs}",
     "mix.exs"
   ],
-  locals_without_parens: [
-    plug: 1,
-    plug: 2,
-    adapter: 1,
-    adapter: 2
-  ]
+  locals_without_parens: export_locals_without_parens,
+  export: [locals_without_parens: export_locals_without_parens]
 ]


### PR DESCRIPTION
Enable importing the formatter config of tesla to the upstream users.

https://hexdocs.pm/mix/Mix.Tasks.Format.html#module-importing-dependencies-configuration