### PR TITLE
Removing useless rescue clause on Timeout middleware

### DIFF
--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -51,9 +51,6 @@ defmodule Tesla.Middleware.Timeout do
     Task.async(fn ->
       try do
         {:ok, func.()}
-      rescue
-        e in _ ->
-          {:error, e}
       catch
         type, value ->
           {type, value}


### PR DESCRIPTION
Just removing a useless `rescue` clause from Timeout middleware. When I coded this method in the project I worked with @emerleite, I didn't know that `catch` also works for raised exceptions.

PS.: No test added because this is a refactoring, this code are already tested on: [timeout_test.exs#L99](https://github.com/teamon/tesla/blob/master/test/tesla/middleware/timeout_test.exs#L99)