### PR TITLE
fix unknown type Part.t

### DIFF
--- a/lib/tesla/multipart.ex
+++ b/lib/tesla/multipart.ex
@@ -28,7 +28,7 @@ defmodule Tesla.Multipart do
             content_type_params: []
 
   @type t :: %__MODULE__{
-          parts: list(Part.t()),
+          parts: list(Tesla.Multipart.Part.t()),
           boundary: String.t(),
           content_type_params: [String.t()]
         }


### PR DESCRIPTION
Hey guys, I'm currently running `mix dialyzer` on your project to ensure everything is valid for usage. I've found some issues and, to make make sure they all go in nicely, having separate PRs for them.

This is the first one which is an unknown type. Mainly because the `Part` was never aliased in. Would this project prefer this structure, or `alias Tesla.Multipart.Part`? I would recommend taking the `Tesla.Multipart.Part` module and putting it in its own file. This would be more conventional and allow developers to find the module easier.