### PR TITLE
fix broken contract with Keyword keys

### DIFF
--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -48,7 +48,7 @@ defmodule Tesla.Adapter.Httpc do
   defp request(method, url, headers, _content_type, %Multipart{} = mp, opts) do
     headers = headers ++ Multipart.headers(mp)
     headers = for {key, value} <- headers, do: {to_charlist(key), to_charlist(value)}
-    {content_type, headers} = Keyword.pop_first(headers, 'Content-Type', 'text/plain')
+    {{_, content_type}, headers} = list_pop_first(headers, 'Content-Type', 'text/plain')
     body = stream_to_fun(Multipart.body(mp))
 
     request(method, url, headers, to_charlist(content_type), body, opts)
@@ -70,4 +70,8 @@ defmodule Tesla.Adapter.Httpc do
 
   defp handle({:error, {:failed_connect, _}}), do: {:error, :econnrefused}
   defp handle(response), do: response
+
+  defp list_pop_first(collection, key, default_value) do
+    List.keytake(collection, key, 0) || {{key, default_value}, collection}
+  end
 end


### PR DESCRIPTION
Offense:

```erlang
lib/tesla/adapter/httpc.ex:51: The call 'Elixir.Keyword':pop_first(Vheaders@3::[any()],"Content-Type",[47 | 97 | 101 | 105 | 108 | 110 | 112 | 116 | 120,...]) breaks the contract (t(),key(),value()) -> {value(),t()}
```

So, it turns out that the Keyword module should _only_ take atoms as keys. Yeah, I know, it's silly. Except, the definition of a keyword list to elixir is where the keys are atoms and the values are any. Reference: https://hexdocs.pm/elixir/Keyword.html#t:key/0

Anywho, since the offender isn't actually a keyword list, but just a standard list, opting for a function that doesn't break the contract with Keyword is preferred. That's when I remade the behavior of `Keyword.pop_first/3` as a private function `list_pop_first/3`.

How it works: Looks up the _first_ key in a collection (first by specifying 0) and returns the value that it finds as a tuple with two tuples inside. If it doesn't find anything, it returns `nil`. Now, this is where the problem occurs between `Keyword.pop_first/3` and `List.key_take/3`: you don't get a default value. To combat this, we have an `||` happen and setup what should be the default value. The only difference is the return value, so we just update the pattern match. Done.