### PR TITLE
update type spec for middleware

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -52,10 +52,6 @@ defmodule Tesla.Client do
             post: []
 end
 
-defmodule Tesla.Middleware do
-  @callback call(env :: Tesla.Env.t(), next :: Tesla.Env.stack(), options :: any) :: Tesla.Env.t()
-end
-
 defmodule Tesla.Builder do
   @http_verbs ~w(head get delete trace options post put patch)a
 

--- a/lib/tesla/middleware.ex
+++ b/lib/tesla/middleware.ex
@@ -1,0 +1,6 @@
+defmodule Tesla.Middleware do
+  alias Tesla.Env
+
+  @callback call(env :: Env.t, next :: Env.stack, options :: any())
+    :: Env.t | {:ok, Env.t} | {:error, any()}
+end

--- a/lib/tesla/middleware/tuples.ex
+++ b/lib/tesla/middleware/tuples.ex
@@ -2,10 +2,12 @@ defmodule Tesla.Middleware.Tuples do
   @behaviour Tesla.Middleware
 
   @moduledoc """
-  Return `:ok` / `:error` tuples for successful HTTP transations, i.e. when the request is completed
-  (no network errors etc) - but it can still be an application-level error (i.e. 404 or 500).
+  Return `:ok` / `:error` tuples for successful HTTP transactions, i.e. when the
+  request is completed (no network errors etc) - but it can still be an
+  application-level error (i.e. 404 or 500).
 
-  **NOTE**: This middleware must be included as the first in the stack (before other middleware)
+  **NOTE**: This middleware must be included as the first in the stack (before
+  other middleware)
 
   ### Example usage
 
@@ -21,8 +23,8 @@ defmodule Tesla.Middleware.Tuples do
   ### Options
   - `:rescue_errors` - list exceptions to be rescued, defaults to `:all` (See below)
 
-  The default behaviour is to rescue Tesla.Error exceptions but let other pass through.
-  It can be customized by passing a `rescue_error:` option:
+  The default behaviour is to rescue Tesla.Error exceptions but let other pass
+  through. It can be customized by passing a `rescue_error:` option:
 
   ### Rescue other exceptions
 
@@ -35,7 +37,6 @@ defmodule Tesla.Middleware.Tuples do
   ```
   plug Tesla.Middleware.Tuples, rescue_errors: :all
   ```
-
   """
   def call(env, next, opts) do
     {:ok, Tesla.run(env, next)}


### PR DESCRIPTION
Offense:

```erlang
lib/tesla/middleware/tuples.ex:40: The inferred return type of call/3 ({'error',_} | {'ok',_}) has nothing in common with #{'__client__':=fun(), '__module__':=atom(), '__struct__':='Elixir.Tesla.Env', 'body':=_, 'headers':=#{binary()=>binary()}, 'method':='delete' | 'get' | 'head' | 'options' | 'patch' | 'post' | 'put' | 'trace', 'opts':=[any()], 'query':=[{atom() | binary(),binary() | [{atom() | binary(),binary() | [{_,_}]}]}], 'status':=integer(), 'url':=binary()}, which is the expected return type for the callback of the 'Elixir.Tesla.Middleware' behaviour
```

The return types from `Tesla.Middleware` was only `Tesla.Env.t`. However, `Tesla.Middleware.Tuples` was returning `{:ok, Env.t} | {:error, any()}`. I've updated the return spec for this. While I was doing this, I updated some of the docs; line endings and s/transations/transactions.