### PR TITLE
add option to log request duration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,9 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :tesla, adapter: :httpc
+config :tesla,
+  adapter: :httpc,
+  log_request_duration: true
 
 config :logger, :console,
   level: :debug,

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -41,8 +41,7 @@ defmodule Tesla.Middleware.Logger do
   end
 
   defp log(env, time) do
-    ms = :io_lib.format("~.3f", [time / 1000])
-    message = "#{normalize_method(env)} #{env.url} -> #{env.status} (#{ms} ms)"
+    message = normalize_message(env, time)
 
     cond do
       env.status >= 400 -> Logger.error(message)
@@ -52,7 +51,18 @@ defmodule Tesla.Middleware.Logger do
   end
 
   defp normalize_method(env) do
-    env.method |> to_string() |> String.upcase()
+    env.method
+    |> to_string
+    |> String.upcase
+  end
+
+  defp normalize_message(env, time) do
+    if Application.get_env(:tesla, :log_request_duration) do
+      ms = :io_lib.format("~.3f", [time / 1000])
+      "#{normalize_method(env)} #{env.url} -> #{env.status} (#{ms} ms)"
+    else
+      "#{normalize_method(env)} #{env.url} -> #{env.status}"
+    end
   end
 end
 


### PR DESCRIPTION
So, over at the company I for, we decided to check Sentry and discovered that when there was an error, Sentry would count each error different based on the message. And the message changed because of the duration. This config option allows messages to, more or less, stay the same for most endpoints.

This solves logging issues for `/api/orders.json`, but not for `/api/orders/R123456789.json`.