### PR TITLE
Customize log levels in Logger middleware

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -20,7 +20,7 @@ defmodule Tesla.Middleware.Logger do
   defmodule MyClient do
     use Tesla
 
-    plug Tesla.Middleware.Logger, [{200, :info}, {300, :warn}, {400, :info}, {500, :error}]
+    plug Tesla.Middleware.Logger, %{404 => :info}
   end
   ```
 
@@ -34,12 +34,7 @@ defmodule Tesla.Middleware.Logger do
 
   require Logger
 
-  @default_log_levels %{
-    200 => :info,
-    300 => :warn,
-    400 => :error,
-    500 => :error
-  }
+  @default_log_levels %{200 => :info, 300 => :warn, 400 => :error, 500 => :error}
 
   def call(env, next, opts) do
     {time, result} = :timer.tc(Tesla, :run, [env, next])
@@ -56,6 +51,7 @@ defmodule Tesla.Middleware.Logger do
     ms = :io_lib.format("~.3f", [time / 1000])
     message = "#{normalize_method(env)} #{env.url} -> #{env.status} (#{ms} ms)"
     log_level = log_level(env.status, log_levels)
+
     case log_level do
       :warn -> Logger.warn(message)
       :error -> Logger.error(message)

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -1,80 +1,104 @@
 defmodule Tesla.Middleware.LoggerTest do
   use ExUnit.Case, async: false
 
-  defmodule Client do
-    use Tesla
+  import ExUnit.CaptureLog
 
-    plug Tesla.Middleware.Logger
-    plug Tesla.Middleware.DebugLogger
+  describe "without log levels" do
+    defmodule Client do
+      use Tesla
 
-    adapter fn env ->
-      env = Tesla.put_header(env, "content-type", "text/plain")
+      plug Tesla.Middleware.Logger
+      plug Tesla.Middleware.DebugLogger
 
-      case env.url do
-        "/connection-error" ->
-          {:error, :econnrefused}
+      adapter fn env ->
+        env = Tesla.put_header(env, "content-type", "text/plain")
 
-        "/server-error" ->
-          {:ok, %{env | status: 500, body: "error"}}
+        case env.url do
+          "/connection-error" ->
+            {:error, :econnrefused}
 
-        "/client-error" ->
-          {:ok, %{env | status: 404, body: "error"}}
+          "/server-error" ->
+            {:ok, %{env | status: 500, body: "error"}}
 
-        "/redirect" ->
-          {:ok, %{env | status: 301, body: "moved"}}
+          "/client-error" ->
+            {:ok, %{env | status: 404, body: "error"}}
 
-        "/ok" ->
-          {:ok, %{env | status: 200, body: "ok"}}
+          "/redirect" ->
+            {:ok, %{env | status: 301, body: "moved"}}
+
+          "/ok" ->
+            {:ok, %{env | status: 200, body: "ok"}}
+        end
       end
+    end
+
+    test "connection error" do
+      log =
+        capture_log(fn ->
+          assert {:error, _} = Client.get("/connection-error")
+        end)
+
+      assert log =~ "/connection-error -> :econnrefused"
+    end
+
+    test "server error" do
+      log = capture_log(fn -> Client.get("/server-error") end)
+      assert log =~ "/server-error -> 500"
+    end
+
+    test "client error" do
+      log = capture_log(fn -> Client.get("/client-error") end)
+      assert log =~ "/client-error -> 404"
+    end
+
+    test "redirect" do
+      log = capture_log(fn -> Client.get("/redirect") end)
+      assert log =~ "/redirect -> 301"
+    end
+
+    test "ok" do
+      log = capture_log(fn -> Client.get("/ok") end)
+      assert log =~ "/ok -> 200"
+    end
+
+    test "ok with params" do
+      log = capture_log(fn -> Client.get("/ok", query: %{"test" => "true"}) end)
+      assert log =~ "Query Param 'test': 'true'"
+    end
+
+    test "multipart" do
+      mp = Tesla.Multipart.new() |> Tesla.Multipart.add_field("field1", "foo")
+      log = capture_log(fn -> Client.post("/ok", mp) end)
+      assert log =~ "boundary: #{mp.boundary}"
+      assert log =~ inspect(List.first(mp.parts))
+    end
+
+    test "stream" do
+      stream = Stream.map(1..10, fn i -> "chunk: #{i}" end)
+      log = capture_log(fn -> Client.post("/ok", stream) end)
+      assert log =~ "/ok -> 200"
     end
   end
 
-  import ExUnit.CaptureLog
+  describe "with log levels" do
+    defmodule ClientWithLogLevels do
+      use Tesla
 
-  test "connection error" do
-    log =
-      capture_log(fn ->
-        assert {:error, _} = Client.get("/connection-error")
-      end)
+      plug Tesla.Middleware.Logger, log_levels: %{404 => :info}
 
-    assert log =~ "/connection-error -> :econnrefused"
-  end
+      adapter fn env ->
+        env = Tesla.put_header(env, "content-type", "text/plain")
 
-  test "server error" do
-    log = capture_log(fn -> Client.get("/server-error") end)
-    assert log =~ "/server-error -> 500"
-  end
+        case env.url do
+          "/not-found" ->
+            {:ok, %{env | status: 404, body: "error"}}
+        end
+      end
+    end
 
-  test "client error" do
-    log = capture_log(fn -> Client.get("/client-error") end)
-    assert log =~ "/client-error -> 404"
-  end
-
-  test "redirect" do
-    log = capture_log(fn -> Client.get("/redirect") end)
-    assert log =~ "/redirect -> 301"
-  end
-
-  test "ok" do
-    log = capture_log(fn -> Client.get("/ok") end)
-    assert log =~ "/ok -> 200"
-  end
-
-  test "ok with params" do
-    log = capture_log(fn -> Client.get("/ok", query: %{"test" => "true"}) end)
-    assert log =~ "Query Param 'test': 'true'"
-  end
-
-  test "multipart" do
-    mp = Tesla.Multipart.new() |> Tesla.Multipart.add_field("field1", "foo")
-    log = capture_log(fn -> Client.post("/ok", mp) end)
-    assert log =~ "boundary: #{mp.boundary}"
-    assert log =~ inspect(List.first(mp.parts))
-  end
-
-  test "stream" do
-    stream = Stream.map(1..10, fn i -> "chunk: #{i}" end)
-    log = capture_log(fn -> Client.post("/ok", stream) end)
-    assert log =~ "/ok -> 200"
+    test "client error" do
+      log = capture_log(fn -> ClientWithLogLevels.get("/not-found") end)
+      assert log =~ "[info] GET /not-found -> 404"
+    end
   end
 end


### PR DESCRIPTION
## Problem

The `Logger` middleware has fixed logger levels for different HTTP status codes. This is an issue when, for example, 404 responses are expected and should be logged with `info` level instead of with `error` level.

## Solution

Be able to pass custom status codes to the middleware.

E.g:

```elixir
defmodule MyClient do
  use Tesla

  plug Tesla.Middleware.Logger, %{404 => :info}
end
```