### PR TITLE
Fix a typo in documentation

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -60,7 +60,7 @@ defmodule Tesla.Middleware.DebugLogger do
   @behaviour Tesla.Middleware
 
   @moduledoc """
-  Log full reqeust/response content
+  Log full request/response content
 
 
   ### Example usage


### PR DESCRIPTION
Just a drive by fix. I accidentally noticed the typo while reading the code.