### PR TITLE
Prefer https for docs coverage svg link (InchCI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Hex.pm](https://img.shields.io/hexpm/dt/tesla.svg)](https://hex.pm/packages/tesla)
 [![Hex.pm](https://img.shields.io/hexpm/dw/tesla.svg)](https://hex.pm/packages/tesla)
 [![codecov](https://codecov.io/gh/teamon/tesla/branch/master/graph/badge.svg)](https://codecov.io/gh/teamon/tesla)
-[![Inline docs](http://inch-ci.org/github/teamon/tesla.svg)](http://inch-ci.org/github/teamon/tesla)
+[![Inline docs](https://inch-ci.org/github/teamon/tesla.svg)](http://inch-ci.org/github/teamon/tesla)
 
 Tesla is an HTTP client loosely based on [Faraday](https://github.com/lostisland/faraday).
 It embraces the concept of middleware when processing the request/response cycle.


### PR DESCRIPTION
I noticed Firefox (at the the Developer Edition) shows a scary looking "connection is not secure" message because this asset is being requested over http:

<img width="1466" alt="screen shot 2018-04-18 at 10 29 37 pm" src="https://user-images.githubusercontent.com/4894936/38968113-1467ad38-4358-11e8-8b68-219cf36c0eeb.png">
<img width="1466" alt="screen shot 2018-04-18 at 10 29 43 pm" src="https://user-images.githubusercontent.com/4894936/38968114-14759bbe-4358-11e8-9cfd-8958c620e0d6.png">
<img width="712" alt="screen shot 2018-04-18 at 10 30 03 pm" src="https://user-images.githubusercontent.com/4894936/38968115-1480e6f4-4358-11e8-9e8c-eadf337c7ec5.png">

And it still works over https: ![SEE!](https://inch-ci.org/github/teamon/tesla.svg) https://inch-ci.org/github/teamon/tesla.svg
