### PR TITLE
[WIP] Update the redirect middleware to preserve the original request

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -15,45 +15,118 @@ defmodule Tesla.Middleware.FollowRedirects do
 
   ### Options
   - `:max_redirects` - limit number of redirects (default: `5`)
+  - `:force_redirect` - If the server response is 301 or 302, proceed with the redirect even
+                        if the original request was neither GET nor HEAD. Default is `false`
+  - `:rewrite_method` - If the server responds is 301 or 302, rewrite the method to GET when
+                        performing the redirect. This will always set the body to nil.
+                        Default is `false`
+  - `:preserve_headers` - Preserve the headers from the original request and send them along in the
+                          redirect. Default is `false`
 
   """
 
   @max_redirects 5
-  @redirect_statuses [301, 302, 307, 308]
+  @force_redirect false
+  @rewrite_method false
+  @preserve_headers false
 
   def call(env, next, opts \\ []) do
-    max = Keyword.get(opts || [], :max_redirects, @max_redirects)
+    opts =
+      opts
+      |> Keyword.put_new(:max_redirects, @max_redirects)
+      |> Keyword.put_new(:force_redirect, @force_redirect)
+      |> Keyword.put_new(:rewrite_method, @rewrite_method)
+      |> Keyword.put_new(:preserve_headers, @preserve_headers)
 
-    redirect(env, next, max)
+    # Initial value for remaining attempts
+    rem = Keyword.fetch!(opts, :max_redirects)
+
+    process_request(env, next, opts, rem)
   end
 
-  defp redirect(env, next, left) when left == 0 do
-    case Tesla.run(env, next) do
-      {:ok, %{status: status} = env} when not (status in @redirect_statuses) ->
-        {:ok, env}
+  # Status codes 301 and 302 were originally included in HTTP/1.0 and may be responded to
+  # differently depending on the user client. Some clients will preserve the original request
+  # method, whereas others will follow the redirect with a `GET`. This method attempts to follow
+  # the original recommendaiton while allowing the user to override default behavior.
+  defp process_response(%{status: status} = env, orig, next, opts, rem)
+       when status in [301, 302] do
+    method = Map.fetch!(env, :method)
+    rewrite_method = Keyword.fetch!(opts, :rewrite_method)
+    force_redirect = Keyword.fetch!(opts, :force_redirect)
 
-      {:ok, _env} ->
-        {:error, {__MODULE__, :too_many_redirects}}
+    with {:ok, env} <- prepare_redirect(orig, env, opts) do
+      cond do
+        method in [:get, :head] and rewrite_method ->
+          process_request(%{env | method: :get, body: nil}, next, opts, rem)
 
-      error ->
-        error
+        method in [:get, :head] ->
+          process_request(env, next, opts, rem)
+
+        force_redirect and rewrite_method ->
+          process_request(%{env | method: :get, body: nil}, next, opts, rem)
+
+        force_redirect ->
+          process_request(env, next, opts, rem)
+
+        true ->
+          {:ok, orig}
+      end
+    else
+      {:error, {:no_location, env}} -> {:ok, env}
     end
   end
 
-  defp redirect(env, next, left) do
-    case Tesla.run(env, next) do
-      {:ok, %{status: status} = env} when status in @redirect_statuses ->
-        case Tesla.get_header(env, "location") do
-          nil ->
-            {:ok, env}
+  # Status code 303 is included in the HTTP/1.1 specification and always redirects with `GET`
+  defp process_response(%{status: 303} = env, orig, next, opts, rem) do
+    with {:ok, env} <- prepare_redirect(orig, env, opts) do
+      process_request(%{env | method: :get, body: nil}, next, opts, rem)
+    else
+      {:error, {:no_location, env}} -> {:ok, env}
+    end
+  end
 
-          location ->
-            location = parse_location(location, env)
-            redirect(%{env | url: location}, next, left - 1)
-        end
+  # Status codes 307 and 308 always perform redirects without modifying the original method
+  defp process_response(%{status: status} = env, orig, next, opts, rem)
+       when status in [307, 308] do
+    with {:ok, env} <- prepare_redirect(orig, env, opts) do
+      process_request(env, next, opts, rem)
+    else
+      {:error, {:no_location, env}} -> {:ok, env}
+    end
+  end
 
-      other ->
-        other
+  defp process_response(env, _, _, _, _), do: {:ok, env}
+
+  defp process_request(env, next, opts, rem) when rem >= 0 do
+    env
+    |> Tesla.run(next)
+    |> case do
+         {:ok, resp} ->
+           process_response(resp, env, next, opts, rem - 1)
+
+         other ->
+           other
+       end
+  end
+
+  defp process_request(_, _, _, _) do
+    {:error, {__MODULE__, :too_many_redirects}}
+  end
+
+  defp prepare_redirect(orig, env, opts) do
+    case Tesla.get_header(env, "location") do
+      nil ->
+        {:error, {:no_location, env}}
+
+      location ->
+        env = %{orig | url: parse_location(location, env), query: []}
+
+        env =
+          if Keyword.fetch!(opts, :preserve_headers),
+             do: env,
+             else: %{env | headers: []}
+
+        {:ok, env}
     end
   end
 

--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -15,120 +15,57 @@ defmodule Tesla.Middleware.FollowRedirects do
 
   ### Options
   - `:max_redirects` - limit number of redirects (default: `5`)
-  - `:force_redirect` - If the server response is 301 or 302, proceed with the redirect even
-                        if the original request was neither GET nor HEAD. Default is `false`
-  - `:rewrite_method` - If the server responds is 301 or 302, rewrite the method to GET when
-                        performing the redirect. This will always set the body to nil.
-                        Default is `false`
-  - `:preserve_headers` - Preserve the headers from the original request and send them along in the
-                          redirect. Default is `false`
 
   """
 
   @max_redirects 5
-  @force_redirect false
-  @rewrite_method false
-  @preserve_headers false
+  @redirect_statuses [301, 302, 303, 307, 308]
 
   def call(env, next, opts \\ []) do
-    opts =
-      opts
-      |> Keyword.put_new(:max_redirects, @max_redirects)
-      |> Keyword.put_new(:force_redirect, @force_redirect)
-      |> Keyword.put_new(:rewrite_method, @rewrite_method)
-      |> Keyword.put_new(:preserve_headers, @preserve_headers)
+    max = Keyword.get(opts || [], :max_redirects, @max_redirects)
 
-    # Initial value for remaining attempts
-    rem = Keyword.fetch!(opts, :max_redirects)
-
-    process_request(env, next, opts, rem)
+    redirect(env, next, max)
   end
 
-  # Status codes 301 and 302 were originally included in HTTP/1.0 and may be responded to
-  # differently depending on the user client. Some clients will preserve the original request
-  # method, whereas others will follow the redirect with a `GET`. This method attempts to follow
-  # the original recommendaiton while allowing the user to override default behavior.
-  defp process_response(%{status: status} = env, orig, next, opts, rem)
-       when status in [301, 302] do
-    method = Map.fetch!(env, :method)
-    rewrite_method = Keyword.fetch!(opts, :rewrite_method)
-    force_redirect = Keyword.fetch!(opts, :force_redirect)
-
-    with {:ok, env} <- prepare_redirect(orig, env, opts) do
-      cond do
-        method in [:get, :head] and rewrite_method ->
-          process_request(%{env | method: :get, body: nil}, next, opts, rem)
-
-        method in [:get, :head] ->
-          process_request(env, next, opts, rem)
-
-        force_redirect and rewrite_method ->
-          process_request(%{env | method: :get, body: nil}, next, opts, rem)
-
-        force_redirect ->
-          process_request(env, next, opts, rem)
-
-        true ->
-          {:ok, orig}
-      end
-    else
-      {:error, {:no_location, env}} -> {:ok, env}
-    end
-  end
-
-  # Status code 303 is included in the HTTP/1.1 specification and always redirects with `GET`
-  defp process_response(%{status: 303} = env, orig, next, opts, rem) do
-    with {:ok, env} <- prepare_redirect(orig, env, opts) do
-      process_request(%{env | method: :get, body: nil}, next, opts, rem)
-    else
-      {:error, {:no_location, env}} -> {:ok, env}
-    end
-  end
-
-  # Status codes 307 and 308 always perform redirects without modifying the original method
-  defp process_response(%{status: status} = env, orig, next, opts, rem)
-       when status in [307, 308] do
-    with {:ok, env} <- prepare_redirect(orig, env, opts) do
-      process_request(env, next, opts, rem)
-    else
-      {:error, {:no_location, env}} -> {:ok, env}
-    end
-  end
-
-  defp process_response(env, _, _, _, _), do: {:ok, env}
-
-  defp process_request(env, next, opts, rem) when rem >= 0 do
-    env
-    |> Tesla.run(next)
-    |> case do
-         {:ok, resp} ->
-           process_response(resp, env, next, opts, rem - 1)
-
-         other ->
-           other
-       end
-  end
-
-  defp process_request(_, _, _, _) do
-    {:error, {__MODULE__, :too_many_redirects}}
-  end
-
-  defp prepare_redirect(orig, env, opts) do
-    case Tesla.get_header(env, "location") do
-      nil ->
-        {:error, {:no_location, env}}
-
-      location ->
-        env = %{orig | url: parse_location(location, env), query: []}
-
-        env =
-          if Keyword.fetch!(opts, :preserve_headers),
-             do: env,
-             else: %{env | headers: []}
-
+  defp redirect(env, next, left) when left == 0 do
+    case Tesla.run(env, next) do
+      {:ok, %{status: status} = env} when not (status in @redirect_statuses) ->
         {:ok, env}
+
+      {:ok, _env} ->
+        {:error, {__MODULE__, :too_many_redirects}}
+
+      error ->
+        error
     end
   end
+
+  defp redirect(env, next, left) do
+    case Tesla.run(env, next) do
+      {:ok, %{status: status} = res} when status in @redirect_statuses ->
+        case Tesla.get_header(res, "location") do
+          nil ->
+            {:ok, res}
+
+          location ->
+            location = parse_location(location, res)
+
+            %{env | status: res.status}
+            |> new_request(location)
+            |> redirect(next, left - 1)
+        end
+
+      other ->
+        other
+    end
+  end
+
+  # The 303 (See Other) redirect was added in HTTP/1.1 to indicate that the originally
+  # requested resource is not available, however a related resource (or another redirect)
+  # available via GET is available at the specified location.
+  # https://tools.ietf.org/html/rfc7231#section-6.4.4
+  defp new_request(%{status: 303} = env, new_location), do: %{env | url: new_location, method: :get}
+  defp new_request(env, new_location), do: %{env | url: new_location}
 
   defp parse_location("/" <> _rest = location, env) do
     env.url


### PR DESCRIPTION
The current `Tesla.Middleware.FollowRedirects` simply updates the url of the response env and tries again. This means that the body from the previous response along with the headers are sent in the next request which can cause unpredictable results.

This PR preserves the original request for each redirect so the body (and optionally headers) can be used in the next request. 

Additionally
- added support for 303 redirects
- add the option to rewrite the method to `:get` on 301 and 302 responses
- optionally prevent or allow redirecting on 301 and 302 responses if the original request was other than `:get` or `:head`

I haven't written tests for all the cases yet, but if it looks good, please let me know and I'd be happy to write them (and fix any bugs I find while doing so)