### PR TITLE
Add @typedoc catch for docs: false

### DIFF
--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -10,6 +10,11 @@ defmodule Tesla.Builder do
       Module.register_attribute(__MODULE__, :__middleware__, accumulate: true)
       Module.register_attribute(__MODULE__, :__adapter__, [])
 
+      if unquote(docs) do
+      else
+        @typedoc false
+      end
+
       @type option ::
               {:method, Tesla.Env.method()}
               | {:url, Tesla.Env.url()}


### PR DESCRIPTION
The intent of this is to provide a method to ignore `@typedoc` in shared libraries. 

Currently, ExDoc will not honor this, but this provides the footing for it to be so.