### PR TITLE
Json middleware custom content type

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -33,6 +33,7 @@ defmodule Tesla.Middleware.JSON do
   ### Options
   - `:decode` - decoding function
   - `:encode` - encoding function
+  - `:encode_content_type` - content-type to be used in request header
   - `:engine` - encode/decode engine, e.g `Jason`, `Poison` or `JSX`  (defaults to Jason)
   - `:engine_opts` - optional engine options
   - `:decode_content_types` - list of additional decodable content-types
@@ -41,6 +42,7 @@ defmodule Tesla.Middleware.JSON do
   # NOTE: text/javascript added to support Facebook Graph API.
   #       see https://github.com/teamon/tesla/pull/13
   @default_content_types ["application/json", "text/javascript"]
+  @default_encode_content_type "application/json"
   @default_engine Jason
 
   def call(env, next, opts) do
@@ -61,7 +63,7 @@ defmodule Tesla.Middleware.JSON do
       {:ok,
        env
        |> Tesla.put_body(body)
-       |> Tesla.put_headers([{"content-type", "application/json"}])}
+       |> Tesla.put_headers([{"content-type", encode_content_type(opts)}])}
     else
       false -> {:ok, env}
       error -> error
@@ -71,6 +73,9 @@ defmodule Tesla.Middleware.JSON do
   defp encode_body(%Stream{} = body, opts), do: {:ok, encode_stream(body, opts)}
   defp encode_body(body, opts) when is_function(body), do: {:ok, encode_stream(body, opts)}
   defp encode_body(body, opts), do: process(body, :encode, opts)
+
+  defp encode_content_type(opts),
+    do: Keyword.get(opts, :encode_content_type, @default_encode_content_type)
 
   defp encode_stream(body, opts) do
     Stream.map(body, fn item ->

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -129,6 +129,17 @@ defmodule Tesla.Middleware.JsonTest do
       assert {:ok, env} = CustomContentTypeClient.get("/decode")
       assert env.body == %{"value" => 123}
     end
+
+    test "set custom request Content-Type header specified in :encode_content_type" do
+      assert {:ok, env} =
+               Tesla.Middleware.JSON.call(
+                 %Tesla.Env{body: %{"foo" => "bar"}},
+                 [],
+                 encode_content_type: "application/x-other-custom-json"
+               )
+
+      assert Tesla.get_header(env, "content-type") == "application/x-other-custom-json"
+    end
   end
 
   describe "EncodeJson / DecodeJson" do


### PR DESCRIPTION
added `encode_content_type` option following the same pattern as `decode_content_types` 

Related Issue https://github.com/teamon/tesla/issues/212