### PR TITLE
Add mock function into Timeout Task's process dictionary

### DIFF
--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -37,8 +37,14 @@ defmodule Tesla.Middleware.Timeout do
   end
 
   defp safe_async(func) do
+    mock_fun = Process.get(Tesla.Mock)
+
     Task.async(fn ->
       try do
+        if(is_function(mock_fun)) do
+          Process.put(Tesla.Mock, mock_fun)
+        end
+
         {:ok, func.()}
       rescue
         e in _ ->

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -104,7 +104,7 @@ defmodule Tesla.Middleware.TimeoutTest do
 
   describe "using Tesla.Mock and timeouts" do
     test "should return the mocked response instead of mock error" do
-      Application.put_env(:tesla, :adapter, Tesla.Mock)
+      Application.put_env(:tesla, MockedClient, adapter: Tesla.Mock)
 
       Tesla.Mock.mock(fn %{method: :get, url: "https://mocked.test.com/path"} ->
         %Tesla.Env{status: 200}

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -49,6 +49,12 @@ defmodule Tesla.Middleware.TimeoutTest do
     end
   end
 
+  defmodule MockedClient do
+    use Tesla
+
+    plug Tesla.Middleware.Timeout
+  end
+
   describe "using custom timeout (100ms)" do
     test "should return timeout error when the stack timeout" do
       assert {:error, :timeout} = Client.get("/sleep_150ms")
@@ -93,6 +99,18 @@ defmodule Tesla.Middleware.TimeoutTest do
 
     test "should repass exit value" do
       assert catch_exit(Client.get("/exit")) == :exit_value
+    end
+  end
+
+  describe "using Tesla.Mock and timeouts" do
+    test "should return the mocked response instead of mock error" do
+      Application.put_env(:tesla, :adapter, Tesla.Mock)
+
+      Tesla.Mock.mock(fn %{method: :get, url: "https://mocked.test.com/path"} ->
+        %Tesla.Env{status: 200}
+      end)
+
+      assert {:ok, %Tesla.Env{status: 200}} = MockedClient.get("https://mocked.test.com/path")
     end
   end
 end


### PR DESCRIPTION
Hello! This is a proposal to fix #157.

I followed @stefanchrobot first suggestion and copied the mock inside `Task` process dictionary.

On the unit tests, I had to define another client since I couldn't figure out a way to reuse the existing one's for this test. Would appreciate any feedback on how to improve it :)