### PR TITLE
Expose the timeout parameter in ibrowse

### DIFF
--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -87,7 +87,8 @@ if Code.ensure_loaded?(:ibrowse) do
     end
 
     defp request(url, headers, method, body, opts) do
-      :ibrowse.send_req(url, headers, method, body, opts)
+      {timeout, opts} = opts |> Keyword.pop(:timeout, 30_000)
+      :ibrowse.send_req(url, headers, method, body, opts, timeout)
     end
 
     defp handle({:error, {:conn_failed, error}}), do: error


### PR DESCRIPTION
Allow passing a :timeout option to the ibrowse adapter, otherwise it will always use its hardcoded 30 second limit.

Example:
```
client =Tesla.build_client()
get(client, "/something", opts: [adapter: [timeout: 120_000]])
```