### PR TITLE
Decode application/x-www-form-urlencoded responses

### DIFF
--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -19,33 +19,59 @@ defmodule Tesla.Middleware.FormUrlencoded do
   ```
   """
 
-  def call(env, next, opts) do
-    opts = opts || []
+  @content_type "application/x-www-form-urlencoded"
 
+  def call(env, next, _opts) do
     env
-    |> encode(opts)
+    |> encode()
     |> Tesla.run(next)
+    |> case do
+      {:ok, env} -> {:ok, decode(env)}
+      error -> error
+    end
   end
 
-  defp encode(env, opts) do
+  defp encode(env) do
     if encodable?(env) do
       env
-      |> Map.update!(:body, &encode_body(&1, opts))
-      |> Tesla.put_headers([{"content-type", "application/x-www-form-urlencoded"}])
+      |> Map.update!(:body, &encode_body(&1))
+      |> Tesla.put_headers([{"content-type", @content_type}])
     else
       env
     end
   end
 
-  defp encode_body(body, _opts) when is_binary(body), do: body
-
-  defp encode_body(body, _opts), do: do_process(body)
-
   defp encodable?(%{body: nil}), do: false
   defp encodable?(%{body: %Tesla.Multipart{}}), do: false
   defp encodable?(_), do: true
 
-  defp do_process(data) do
-    URI.encode_query(data)
+  defp encode_body(body) when is_binary(body), do: body
+  defp encode_body(body), do: do_encode(body)
+
+  defp decode(env) do
+    if decodable?(env) do
+      env
+      |> Map.update!(:body, &decode_body(&1))
+    else
+      env
+    end
   end
+
+  defp decodable?(env), do: decodable_body?(env) && decodable_content_type?(env)
+
+  defp decodable_body?(env) do
+    (is_binary(env.body) && env.body != "") || (is_list(env.body) && env.body != [])
+  end
+
+  defp decodable_content_type?(env) do
+    case Tesla.get_header(env, "content-type") do
+      nil -> false
+      content_type -> String.starts_with?(content_type, @content_type)
+    end
+  end
+
+  defp decode_body(body), do: do_decode(body)
+
+  defp do_encode(data), do: URI.encode_query(data)
+  defp do_decode(data), do: URI.decode_query(data)
 end

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -14,6 +14,10 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
 
           "/check_incoming_content_type" ->
             {201, [{"content-type", "text/html"}], Tesla.get_header(env, "content-type")}
+
+          "/decode_response" ->
+            {200, [{"content-type", "application/x-www-form-urlencoded; charset=utf-8"}],
+             "x=1&y=2"}
         end
 
       {:ok, %{env | status: status, headers: headers, body: body}}
@@ -33,6 +37,11 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
   test "check header is set as application/x-www-form-urlencoded" do
     assert {:ok, env} = Client.post("/check_incoming_content_type", %{"foo" => "%bar "})
     assert env.body == "application/x-www-form-urlencoded"
+  end
+
+  test "decode response" do
+    assert {:ok, env} = Client.get("/decode_response")
+    assert env.body == %{"x" => "1", "y" => "2"}
   end
 
   defmodule MultipartClient do


### PR DESCRIPTION
Somehow the `Tesla.Middleware.FormUrlencoded` middleware is missing the decoding part 🐌 