### PR TITLE
Fix dialyzer warning for Multipart.part_stream type

### DIFF
--- a/lib/tesla/multipart.ex
+++ b/lib/tesla/multipart.ex
@@ -34,7 +34,7 @@ defmodule Tesla.Multipart do
   @boundary_chars "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
                   |> String.split("")
 
-  @type part_stream :: IO.Stream.t() | File.Stream.t()
+  @type part_stream :: IO.Stream.t() | File.Stream.t() | Enumerable.t()
   @type part_value :: iodata | part_stream
 
   defstruct parts: [],

--- a/lib/tesla/multipart.ex
+++ b/lib/tesla/multipart.ex
@@ -34,7 +34,7 @@ defmodule Tesla.Multipart do
   @boundary_chars "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
                   |> String.split("")
 
-  @type part_stream :: IO.Stream.t() | File.Stream.t() | Enumerable.t()
+  @type part_stream :: Enum.t()
   @type part_value :: iodata | part_stream
 
   defstruct parts: [],


### PR DESCRIPTION
Dialyzer output without this change:

```
lib/tesla/multipart.ex:130:invalid_contract
Invalid type specification for function.

Function:
Tesla.Multipart.body/1

Success typing:
@spec body(%Tesla.Multipart{:boundary => _, :parts => _, _ => _}) ::
  (_, _ -> {:halted, _} | {:suspended, _, (_ -> any())})
________________________________________________________________________________
lib/tesla/multipart.ex:137:invalid_contract
Invalid type specification for function.

Function:
Tesla.Multipart.part_as_stream/2

Success typing:
@spec part_as_stream(%Tesla.Multipart.Part{:body => _, :dispositions => [{_, _}], :headers => _, _ => _}, _) ::
  (_, _ -> {:halted, _} | {:suspended, _, (_ -> any())})
________________________________________________________________________________
```

The return type of `Stream.concat` is just `Enumerable.t()`. I'm not sure if we can do anything about this other than adding `| Enumerable.t()` to the `part_stream` type.