### PR TITLE
Fix for logging headers with nil value. 

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -202,7 +202,9 @@ defmodule Tesla.Middleware.Logger do
   end
 
   defp debug_headers([]), do: @debug_no_headers
-  defp debug_headers(headers), do: Enum.map(headers, fn {k, v} -> [k, ": ", v, ?\n] end)
+
+  defp debug_headers(headers),
+    do: Enum.map(headers, fn {k, v} -> [to_string(k), ": ", to_string(v), ?\n] end)
 
   defp debug_body(nil), do: @debug_no_body
   defp debug_body([]), do: @debug_no_body

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -134,6 +134,29 @@ defmodule Tesla.Middleware.LoggerTest do
     end
   end
 
+  describe "Debug mode for headers" do
+    setup do
+      Logger.configure(level: :debug)
+      :ok
+    end
+
+    defmodule CustomHeaderClient do
+      use Tesla
+
+      plug Tesla.Middleware.Logger
+
+      adapter fn env ->
+        env = Tesla.put_header(env, "x-custom-header", nil)
+        {:ok, %{env | status: 200, body: "ok"}}
+      end
+    end
+
+    test "ok with empty header" do
+      log = capture_log(fn -> CustomHeaderClient.post("/", %{}) end)
+      assert log =~ "x-custom-header"
+    end
+  end
+
   describe "with log_level" do
     defmodule ClientWithLogLevel do
       use Tesla


### PR DESCRIPTION
I've discovered this issue during Tesla upgrade from 0.x to 1.x 

In 0.x we had https://github.com/teamon/tesla/blob/0.x/lib/tesla/middleware/logger.ex#L143 - because value of the header is interpolated here elixir will automatically call to_string on it.

In 1.x we have https://github.com/teamon/tesla/blob/master/lib/tesla/middleware/logger.ex#L205 - which essentially calls `Logger.debug([k, “: “, v, ?\n])` - trying to log nil inside this array here will cause the logger to blow up: 

```
iex(2)> client = Tesla.client([
  {Tesla.Middleware.BaseUrl, "http://github.com"},
  fn env, next ->
    env
    |> Tesla.put_header("mjornir", nil)
    |> Tesla.run(next)
  end,
  Tesla.Middleware.Logger
])

iex(2)> Tesla.get(client, "/")

12:08:58.242 [warn]  GET http://github.com/ -> 301 (100.693 ms)
** (ArgumentError) cannot truncate chardata because it contains something that is not valid chardata: nil
    (logger) lib/logger/utils.ex:78: Logger.Utils.truncate_n/2
    (logger) lib/logger/utils.ex:88: Logger.Utils.truncate_n_list/3
    (logger) lib/logger/utils.ex:48: Logger.Utils.truncate/2
    (logger) lib/logger.ex:686: Logger.__do_log__/3
    (tesla) lib/tesla/middleware/logger.ex:128: Tesla.Middleware.Logger.call/3
```
