### PR TITLE
Allow vanilla Stream

### DIFF
--- a/lib/tesla/multipart.ex
+++ b/lib/tesla/multipart.ex
@@ -181,8 +181,7 @@ defmodule Tesla.Multipart do
 
   @spec assert_part_value!(any) :: :ok | no_return
   defp assert_part_value!(%maybe_stream{})
-       when maybe_stream == IO.Stream
-       when maybe_stream == File.Stream,
+       when maybe_stream in [IO.Stream, File.Stream, Stream],
        do: :ok
 
   defp assert_part_value!(value)

--- a/test/tesla/multipart_test.exs
+++ b/test/tesla/multipart_test.exs
@@ -271,6 +271,24 @@ defmodule Tesla.MultipartTest do
         |> Multipart.add_field("foo", %File.Stream{})
 
       assert is_function(Multipart.body(mp))
+
+      stream = File.stream!("test/tesla/multipart_test_file.sh")
+
+      mp2 =
+        Multipart.new()
+        |> Multipart.add_field("bar", stream)
+
+      assert is_function(Multipart.body(mp2))
+    end
+
+    test "normal stream" do
+      stream = Stream.map([1, 2, 3], fn x -> to_string(x) end)
+
+      mp =
+        Multipart.new()
+        |> Multipart.add_field("foo", stream)
+
+      assert is_function(Multipart.body(mp))
     end
   end
 end


### PR DESCRIPTION
This fixes a bug I introduced in #251 where
vanilla streams now raise an ArgumentError