### PR TITLE
Filter sensitive headers in debug logs with :sanitize_headers

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -132,7 +132,6 @@ defmodule Tesla.Middleware.Logger do
 
   def call(env, next, opts) do
     {time, response} = :timer.tc(Tesla, :run, [env, next])
-
     level = log_level(response, opts)
     Logger.log(level, fn -> Formatter.format(env, response, time, @format) end)
 

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -54,7 +54,7 @@ defmodule Tesla.Middleware.Logger do
 
   ### Options
   - `:log_level` - custom function for calculating log level (see below)
-  - `:sanitize_headers` - sanitizes sensitive headers before logging in debug mode
+  - `:filter_headers` - sanitizes sensitive headers before logging in debug mode
 
   ## Custom log format
 
@@ -111,12 +111,12 @@ defmodule Tesla.Middleware.Logger do
   #### Sanitize headers
 
   To sanitize sensitive headers such as `authorization` in
-  debug logs, add them to the `:sanitize_headers` option.
+  debug logs, add them to the `:filter_headers` option.
 
   ```
   # config/dev.local.exs
   config :tesla, Tesla.Middleware.Logger,
-    sanitize_headers: ["authorization"]
+    filter_headers: ["authorization"]
   ```
   """
 
@@ -136,7 +136,7 @@ defmodule Tesla.Middleware.Logger do
     Logger.log(level, fn -> Formatter.format(env, response, time, @format) end)
 
     if Keyword.get(@config, :debug, true) do
-      env = sanitize_headers(env, Keyword.get(opts, :sanitize_headers, []))
+      env = filter_headers(env, Keyword.get(opts, :filter_headers, []))
       Logger.debug(fn -> debug(env, response) end)
     end
 
@@ -237,18 +237,18 @@ defmodule Tesla.Middleware.Logger do
   defp debug_body(data) when is_binary(data) or is_list(data), do: data
   defp debug_body(term), do: inspect(term)
 
-  defp sanitize_headers(env, []), do: env
+  defp filter_headers(env, []), do: env
 
-  defp sanitize_headers(env, sanitize_headers) when is_list(sanitize_headers) do
+  defp filter_headers(env, filter_headers) when is_list(filter_headers) do
     headers =
       env.headers
       |> Enum.map(fn {key, val} ->
-        val = if key in sanitize_headers, do: "[FILTERED]", else: val
+        val = if key in filter_headers, do: "[FILTERED]", else: val
         {key, val}
       end)
 
     %Tesla.Env{env | headers: headers}
   end
 
-  defp sanitize_headers(env, _), do: env
+  defp filter_headers(env, _), do: env
 end

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -54,7 +54,7 @@ defmodule Tesla.Middleware.Logger do
 
   ### Options
   - `:log_level` - custom function for calculating log level (see below)
-  - `:filter_headers` - sanitizes sensitive headers before logging in debug mode
+  - `:filter_headers` - sanitizes sensitive headers before logging in debug mode (see below)
 
   ## Custom log format
 
@@ -108,10 +108,11 @@ defmodule Tesla.Middleware.Logger do
   # config/dev.local.exs
   config :tesla, Tesla.Middleware.Logger, debug: false
   ```
-  #### Sanitize headers
+  #### Filter headers
 
   To sanitize sensitive headers such as `authorization` in
   debug logs, add them to the `:filter_headers` option.
+  `:filter_headers` expects a list of header names as strings.
 
   ```
   # config/dev.local.exs
@@ -215,8 +216,7 @@ defmodule Tesla.Middleware.Logger do
   defp debug_headers([], _opts), do: @debug_no_headers
 
   defp debug_headers(headers, opts) do
-    filtered = Keyword.get(opts, :filter_headers)
-    filtered = if is_list(filtered), do: filtered, else: []
+    filtered = Keyword.get(opts, :filter_headers, [])
 
     Enum.map(headers, fn {k, v} ->
       v = if k in filtered, do: "[FILTERED]", else: v

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -177,16 +177,16 @@ defmodule Tesla.Middleware.LoggerTest do
     end
   end
 
-  describe "with sanitize_headers" do
+  describe "with filter_headers" do
     setup do
       Logger.configure(level: :debug)
       :ok
     end
 
-    defmodule ClientWithSanitizeHeaders do
+    defmodule ClientWithFilterHeaders do
       use Tesla
 
-      plug Tesla.Middleware.Logger, sanitize_headers: ["authorization"]
+      plug Tesla.Middleware.Logger, filter_headers: ["authorization"]
 
       adapter fn env ->
         case env.url do
@@ -202,7 +202,7 @@ defmodule Tesla.Middleware.LoggerTest do
         {"other-header", "is not filtered"}
       ]
 
-      log = capture_log(fn -> ClientWithSanitizeHeaders.get("/ok", headers: headers) end)
+      log = capture_log(fn -> ClientWithFilterHeaders.get("/ok", headers: headers) end)
 
       assert log =~ "authorization: [FILTERED]"
       assert log =~ "other-header: is not filtered"


### PR DESCRIPTION
Basically the same as Phoenix' `config :phoenix, :filter_parameters, ["password", "secret"]` but for Tesla debug logs and headers.

```elixir
# your client
plug Tesla.Middleware.Logger, filter_headers: ["authorization"]

# >> REQUEST >>>
# authorization: [FILTERED]
# user-agent: Mozilla
# << RESPONSE <<
# ...
```

While you generally don't want to enable debug logs in production, it can be useful to do so once in a while. 