### PR TITLE
Allow nil path on BaseUrl middleware to use the base as-is

### DIFF
--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -15,6 +15,7 @@ defmodule Tesla.Middleware.BaseUrl do
     plug Tesla.Middleware.BaseUrl, "https://api.github.com"
   end
 
+  MyClient.get(nil) # equals to GET http://example.com
   MyClient.get("/path") # equals to GET https://api.github.com/path
   MyClient.get("http://example.com/path") # equals to GET http://example.com/path
   ```
@@ -27,11 +28,11 @@ defmodule Tesla.Middleware.BaseUrl do
   end
 
   defp apply_base(env, base) do
-    if Regex.match?(~r/^https?:\/\//, env.url) do
+    cond do
+      is_nil(env.url) -> %{env | url: base}
       # skip if url is already with scheme
-      env
-    else
-      %{env | url: join(base, env.url)}
+      Regex.match?(~r/^https?:\/\//, env.url) -> env
+      true -> %{env | url: join(base, env.url)}
     end
   end
 

--- a/test/tesla/middleware/base_url_test.exs
+++ b/test/tesla/middleware/base_url_test.exs
@@ -4,6 +4,16 @@ defmodule Tesla.Middleware.BaseUrlTest do
 
   @middleware Tesla.Middleware.BaseUrl
 
+  test "base without slash, nil path" do
+    assert {:ok, env} = @middleware.call(%Env{url: nil}, [], "http://example.com/top")
+    assert env.url == "http://example.com/top"
+  end
+
+  test "base with slash, nil path" do
+    assert {:ok, env} = @middleware.call(%Env{url: nil}, [], "http://example.com/top/")
+    assert env.url == "http://example.com/top/"
+  end
+
   test "base without slash, path without slash" do
     assert {:ok, env} = @middleware.call(%Env{url: "path"}, [], "http://example.com")
     assert env.url == "http://example.com/path"


### PR DESCRIPTION
To reuse client, I use `Tesla.Middleware.BaseUrl` with full url (i.e. with path). Currently the middleware does not provide a way to use the base url as-is.

This change introduces new behaviour: this was not allowed previously (it gives an error to concat nil to string), so it's not breaking change.