### PR TITLE
Base url improve: case-insensitive scheme and keep empty path

### DIFF
--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -27,7 +27,7 @@ defmodule Tesla.Middleware.BaseUrl do
   end
 
   defp apply_base(env, base) do
-    if Regex.match?(~r/^https?:\/\//, env.url) do
+    if Regex.match?(~r/^https?:\/\//i, env.url) do
       # skip if url is already with scheme
       env
     else

--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -12,11 +12,13 @@ defmodule Tesla.Middleware.BaseUrl do
   defmodule MyClient do
     use Tesla
 
-    plug Tesla.Middleware.BaseUrl, "https://api.github.com"
+    plug Tesla.Middleware.BaseUrl, "https://example.com/foo"
   end
 
-  MyClient.get("/path") # equals to GET https://api.github.com/path
-  MyClient.get("http://example.com/path") # equals to GET http://example.com/path
+  MyClient.get("/path") # equals to GET https://example.com/foo/path
+  MyClient.get("path") # equals to GET https://example.com/foo/path
+  MyClient.get("") # equals to GET https://example.com/foo
+  MyClient.get("http://example.com/bar") # equals to GET http://example.com/bar
   ```
   """
 
@@ -40,6 +42,7 @@ defmodule Tesla.Middleware.BaseUrl do
       {nil, url} -> url
       {"/", "/" <> rest} -> base <> rest
       {"/", rest} -> base <> rest
+      {_, ""} -> base
       {_, "/" <> rest} -> base <> "/" <> rest
       {_, rest} -> base <> "/" <> rest
     end

--- a/test/tesla/middleware/base_url_test.exs
+++ b/test/tesla/middleware/base_url_test.exs
@@ -1,8 +1,18 @@
 defmodule Tesla.Middleware.BaseUrlTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Tesla.Env
 
   @middleware Tesla.Middleware.BaseUrl
+
+  test "base without slash, empty path" do
+    assert {:ok, env} = @middleware.call(%Env{url: ""}, [], "http://example.com")
+    assert env.url == "http://example.com"
+  end
+
+  test "base with slash, empty path" do
+    assert {:ok, env} = @middleware.call(%Env{url: ""}, [], "http://example.com/")
+    assert env.url == "http://example.com/"
+  end
 
   test "base without slash, path without slash" do
     assert {:ok, env} = @middleware.call(%Env{url: "path"}, [], "http://example.com")
@@ -24,7 +34,37 @@ defmodule Tesla.Middleware.BaseUrlTest do
     assert env.url == "http://example.com/path"
   end
 
-  test "skip double append" do
+  test "base and path without slash, empty path" do
+    assert {:ok, env} = @middleware.call(%Env{url: ""}, [], "http://example.com/top")
+    assert env.url == "http://example.com/top"
+  end
+
+  test "base and path with slash, empty path" do
+    assert {:ok, env} = @middleware.call(%Env{url: ""}, [], "http://example.com/top/")
+    assert env.url == "http://example.com/top/"
+  end
+
+  test "base and path without slash, path without slash" do
+    assert {:ok, env} = @middleware.call(%Env{url: "path"}, [], "http://example.com/top")
+    assert env.url == "http://example.com/top/path"
+  end
+
+  test "base and path without slash, path with slash" do
+    assert {:ok, env} = @middleware.call(%Env{url: "/path"}, [], "http://example.com/top")
+    assert env.url == "http://example.com/top/path"
+  end
+
+  test "base and path with slash, path without slash" do
+    assert {:ok, env} = @middleware.call(%Env{url: "path"}, [], "http://example.com/top/")
+    assert env.url == "http://example.com/top/path"
+  end
+
+  test "base and path with slash, path with slash" do
+    assert {:ok, env} = @middleware.call(%Env{url: "/path"}, [], "http://example.com/top/")
+    assert env.url == "http://example.com/top/path"
+  end
+
+  test "skip double append on http / https" do
     assert {:ok, env} = @middleware.call(%Env{url: "http://other.foo"}, [], "http://example.com")
     assert env.url == "http://other.foo"
 

--- a/test/tesla/middleware/base_url_test.exs
+++ b/test/tesla/middleware/base_url_test.exs
@@ -27,5 +27,16 @@ defmodule Tesla.Middleware.BaseUrlTest do
   test "skip double append" do
     assert {:ok, env} = @middleware.call(%Env{url: "http://other.foo"}, [], "http://example.com")
     assert env.url == "http://other.foo"
+
+    assert {:ok, env} = @middleware.call(%Env{url: "https://other.foo"}, [], "http://example.com")
+    assert env.url == "https://other.foo"
+  end
+
+  test "skip double append on http / https in different case" do
+    assert {:ok, env} = @middleware.call(%Env{url: "Http://other.foo"}, [], "http://example.com")
+    assert env.url == "Http://other.foo"
+
+    assert {:ok, env} = @middleware.call(%Env{url: "HTTPS://other.foo"}, [], "http://example.com")
+    assert env.url == "HTTPS://other.foo"
   end
 end


### PR DESCRIPTION
Replace #267

## Changes

- Update doc and test for base url with path
- Previously, when empty url is given, the result url would have always `/` at the end. Now this behavior is changed to keep the original url (as in the base url middleware) as-is.
- Allow different case for http(s).

## Note

- No change for type (`url` is still expected be a string)
- I thought of using `URI.parse/1`, but just leave the current behaviour (passing only http(s))

```elixir
  defp apply_base(%{url: url} = env, base) do
    case URI.parse(url) do
      %{scheme: nil} -> %{env | url: join(base, url)}
      _ -> env
    end
  end
```