### PR TITLE
content-type for the text/2 mock should probably be 'text/plain', not…

### DIFF
--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -170,7 +170,7 @@ defmodule Tesla.Mock do
       end
   """
   @spec text(body :: term, opts :: [Tesla.option()]) :: Tesla.Env.t()
-  def text(body, opts \\ []), do: response(body, "test/plain", opts)
+  def text(body, opts \\ []), do: response(body, "text/plain", opts)
 
   defp response(body, content_type, opts) do
     defaults = [status: 200, headers: [{"content-type", content_type}]]


### PR DESCRIPTION
… 'test/plain'

Given that this is in a mock module, `test/plain` does seem somewhat appropriate, though :)