### PR TITLE
Add support for Hypertext Application Language

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -41,7 +41,7 @@ defmodule Tesla.Middleware.JSON do
 
   # NOTE: text/javascript added to support Facebook Graph API.
   #       see https://github.com/teamon/tesla/pull/13
-  @default_content_types ["application/json", "text/javascript"]
+  @default_content_types ["application/json", "application/hal+json", "text/javascript"]
   @default_encode_content_type "application/json"
   @default_engine Jason
 

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -42,6 +42,10 @@ defmodule Tesla.Middleware.JsonTest do
             "/stream" ->
               list = env.body |> Enum.to_list() |> Enum.join("---")
               {200, [], list}
+
+            "/haljson" ->
+              {200, [{"content-type", "application/hal+json"}],
+               "{\"id\": 123, \"_links\":{\"self\":{\"href\":\"https://foo.bar/123\"}}}"}
           end
 
         {:ok, %{env | status: status, headers: headers, body: body}}
@@ -105,6 +109,15 @@ defmodule Tesla.Middleware.JsonTest do
 
     test "raise error when decoding non-utf8 json" do
       assert {:error, {Tesla.Middleware.JSON, :decode, _}} = Client.get("/invalid-json-encoding")
+    end
+
+    test "decode HAL + JSON body" do
+      assert {:ok, env} = Client.get("/haljson")
+
+      assert env.body == %{
+               "id" => 123,
+               "_links" => %{"self" => %{"href" => "https://foo.bar/123"}}
+             }
     end
   end
 


### PR DESCRIPTION
HAL (http://stateless.co/hal_specification.html) is a simple format that gives a consistent and easy way to hyperlink between resources in your API.

The goal of this PR is to add this _content type_ to the default ones.

Closes #277.

