### PR TITLE
Updated deprecated adapter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Using `adapter` macro:
 defmodule GitHub do
   use Tesla
 
-  adapter :hackney, recv_timeout: 30_000, ssl: [certfile: "certs/client.crt"]
+  adapter Tesla.Adapter.Hackney, recv_timeout: 30_000, ssl: [certfile: "certs/client.crt"]
 end
 ```
 


### PR DESCRIPTION
This example of setting the middleware for an api client throws the following compile errors

```
** (CompileError) lib/integration_tester/aversion_client.ex:7:
    Adapter aliases and local functions has been removed.
    Use full adapter name or define a middleware module Hackney

        adapter :hackney

    See https://github.com/teamon/tesla/wiki/0.x-to-1.0-Migration-Guide#dropped-aliases-support-159
```

The updated example compiles correctly.