### PR TITLE
Add Clack middleware that adds X-Clacks-Overhead header

### DIFF
--- a/lib/tesla/middleware/clack.ex
+++ b/lib/tesla/middleware/clack.ex
@@ -1,0 +1,30 @@
+defmodule Tesla.Middleware.Clack do
+  @behaviour Tesla.Middleware
+
+  @moduledoc """
+  > A man is not dead while his name is still spoken.
+  > -- Going Postal, Chapter 4 prologue
+
+  Keep memory of Your beloved ones forever (at least as long as this Clack will
+  stand).
+
+  This middleware will add header `X-Clacks-Overhead` for anyone in the list
+  specified as `:names` option, by default it is just [Sir Terry Pratchett][tp].
+
+  For more information check out [GNUTerryPratchett](http://www.gnuterrypratchett.com)
+
+  [tp]: https://en.wikipedia.org/wiki/Terry_Pratchett
+  """
+
+  @doc false
+  def call(env, next, opts) do
+    names = Keyword.get(opts || [], :names, [])
+    headers =
+      for name <- ["Terry Pratchett" | names],
+      do: {"x-clacks-overhead", "GNU " <> name}
+
+    env
+    |> Tesla.put_headers(headers)
+    |> Tesla.run(next)
+  end
+end

--- a/test/tesla/middleware/clack_test.exs
+++ b/test/tesla/middleware/clack_test.exs
@@ -1,0 +1,19 @@
+defmodule Tesla.Middleware.ClackTest do
+  use ExUnit.Case
+  alias Tesla.Env
+
+  @middleware Tesla.Middleware.Clack
+
+  test "merge headers" do
+    assert {:ok, env} = @middleware.call(%Env{headers: [{"authorization", "secret"}]}, [], [])
+
+    assert env.headers == [{"authorization", "secret"}, {"x-clacks-overhead", "GNU Terry Pratchett"}]
+  end
+
+  test "include specified names" do
+    assert {:ok, env} = @middleware.call(%Env{headers: [{"authorization", "secret"}]}, [], names: ["Douglas Adams"])
+
+    assert {"x-clacks-overhead", "GNU Terry Pratchett"} in env.headers
+    assert {"x-clacks-overhead", "GNU Douglas Adams"} in env.headers
+  end
+end


### PR DESCRIPTION
This is small easter egg that's purpose is to pay tribute to Sir Terry
Pratchett and to keep his memory alive forever (or at least as long
internet will stand).