### PR TITLE
Add typechecking for different output format from :timer.tc

### DIFF
--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -24,6 +24,7 @@ defmodule Tesla.Middleware.Telemetry do
   @doc false
   def call(env, next, _opts) do
     {time, res} = :timer.tc(Tesla, :run, [env, next])
+    time = if is_number(time), do: time, else: Map.get(time, :value, 0)
     :telemetry.execute([:tesla, :request], time, %{result: res})
     res
   end


### PR DESCRIPTION
Don't know the exact reason why the return value for ```:timer.tc/3``` become a map in Elixir: 1.5.3 OTP Release: 20.2.
Here is a quick fix on it.