### PR TITLE
Use correct SSL options for Hackney

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Using `adapter` macro:
 defmodule GitHub do
   use Tesla
 
-  adapter Tesla.Adapter.Hackney, recv_timeout: 30_000, ssl: [certfile: "certs/client.crt"]
+  adapter Tesla.Adapter.Hackney, recv_timeout: 30_000, ssl_options: [certfile: "certs/client.crt"]
 end
 ```
 


### PR DESCRIPTION
Setting `ssl` has no effect, the option in hackney is called `ssl_options`