### PR TITLE
Adding telemetry docs to mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -115,6 +115,7 @@ defmodule Tesla.Mixfile do
           Tesla.Middleware.Opts,
           Tesla.Middleware.Query,
           Tesla.Middleware.Retry,
+          Tesla.Middleware.Telemetry,
           Tesla.Middleware.Timeout
         ]
       ],


### PR DESCRIPTION
I have just realized I didn't add the middleware module onto the mix.exs.
So, just have a pr on this.