### PR TITLE
Allows put_headers to work with a nil header argument

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -412,7 +412,9 @@ defmodule Tesla do
     %{env | headers: headers}
   end
 
-  @spec put_headers(Env.t(), [{binary, binary}]) :: Env.t()
+  @spec put_headers(Env.t(), [{binary, binary}] | nil) :: Env.t()
+  def put_headers(%Env{} = env, nil), do: env
+
   def put_headers(%Env{} = env, list) when is_list(list) do
     %{env | headers: env.headers ++ list}
   end

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -256,6 +256,10 @@ defmodule TeslaTest do
       assert get_header(env, "server") == "Cowboy"
       assert get_header(env, "content-length") == "100"
       assert get_header(env, "content-type") == "text/plain"
+
+      headers = Map.get(env, :headers)
+      env = Tesla.put_headers(env, nil)
+      assert headers == Map.get(env, :headers)
     end
 
     test "add multiple headers with the same name" do


### PR DESCRIPTION
I don't know if this is the best way to fix it or not, but I thought I
would put something out there to get the conversation going. I don't
like having `nil` passed in place of an empty list, but that was already
happening above.

Amos King @adkron <amos@binarynoggin.com>

closed #298