### PR TITLE
Allows DigestAuth to work with Hackney using the async option

### DIFF
--- a/test/tesla/adapter/hackney_test.exs
+++ b/test/tesla/adapter/hackney_test.exs
@@ -22,4 +22,14 @@ defmodule Tesla.Adapter.HackneyTest do
     assert {:ok, %Env{} = response} = call(request, with_body: true)
     assert response.status == 200
   end
+
+  test "get with `with_body: true` option even when async" do
+    request = %Env{
+      method: :get,
+      url: "#{@http}/ip"
+    }
+
+    assert {:ok, %Env{} = response} = call(request, with_body: true, async: true)
+    assert response.status == 200
+  end
 end


### PR DESCRIPTION
The Hackney handler was not handling the async option correctly. The problem is
that Hackney would return `{:ok, ref}` as an asynchronous response and the
caller is expected to process messages using that reference.

The Hackney adapter did not have a handler for the `{:ok, ref}`. I added a
handler for the `{:ok, ref}` response that waits for the header and status
messages from Hackney, but passes back the `ref` as the body of the response.
The reason is that some async requests are long-living and require the end user
to implement the streaming data, i.e. mjpg. The header and the status should not
take much time and are expected in many instances.

No changes were needed in the DigestAuth module since DigestAuth doesn't use the
body.

I was able to use this on an mjpg async call and use a handler for the body
messages. The handler did have to receive messages like `{:hackney_response,
ref, bin}`, but I didn't think that we should capture that message to
change the message key to something like `{:tesla_response, ref, bin}`.

closes #302 

Amos King @adkron <amos@binarynoggin.com>