### PR TITLE
Add status to Tesla.option type

### DIFF
--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -16,6 +16,7 @@ defmodule Tesla.Builder do
               | {:query, Tesla.Env.query()}
               | {:headers, Tesla.Env.headers()}
               | {:body, Tesla.Env.body()}
+              | {:status, Tesla.Env.status()}
               | {:opts, Tesla.Env.opts()}
 
       if unquote(docs) do


### PR DESCRIPTION
## Adding `status` to `Tesla.option/0`
While trying to silence some dialyzer errors I noticed for every time I was calling an equivalent of `Mock.json(json(%{"some" => "data"}, status: 404)` like in the documentation for `json/2`, ElixirLS picked up that `status` does not exist in `Tesla.option()`.

All other fields in `Tesla.t()` are included in the option type but that one, so I'm assuming it was just missed?