### PR TITLE
Fix relative redirect support

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -68,12 +68,13 @@ defmodule Tesla.Middleware.FollowRedirects do
   defp new_request(%{status: 303} = env, location), do: %{env | url: location, method: :get}
   defp new_request(env, location), do: %{env | url: location}
 
-  defp parse_location("/" <> _rest = location, env) do
+  defp parse_location("https://" <> _rest = location, _env), do: location
+  defp parse_location("http://" <> _rest = location, _env), do: location
+
+  defp parse_location(location, env) do
     env.url
     |> URI.parse()
     |> URI.merge(location)
     |> URI.to_string()
   end
-
-  defp parse_location(location, _env), do: location
 end

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -85,6 +85,12 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
 
           "https://example.com/article" ->
             {301, [{"location", "/pl"}], ""}
+
+          "https://example.com/one/two" ->
+            {301, [{"location", "three"}], ""}
+
+          "https://example.com/one/three" ->
+            {200, [{"content-type", "text/plain"}], "foo bar baz"}
         end
 
       {:ok, %{env | status: status, headers: headers, body: body}}
@@ -106,6 +112,11 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
   test "rewrites URLs to their root" do
     assert {:ok, env} = RLClient.get("https://example.com/article")
     assert env.url == "https://example.com/pl"
+  end
+
+  test "rewrites URLs relative to the original URL" do
+    assert {:ok, env} = RLClient.get("https://example.com/one/two")
+    assert env.url == "https://example.com/one/three"
   end
 
   defmodule CustomRewriteMethodClient do


### PR DESCRIPTION
Redirects can be relative to the current URL.

e.g.

```elixir
iex(sr2@test)3> Tesla.get("https://webmention.rocks/test/23/page")
{:ok,
 %Tesla.Env{
   # …
   headers: [
     {"location", "page/wjj46SaVj1OnFIzTBDwA"}, # …
   ],
   status: 302,
 }}
```

so it's the `^https?://` case where we can bypass URI parsing. In other cases, let `URI.merge` do its thing.