### PR TITLE
Fix telemetry warning

### DIFF
--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -1,30 +1,32 @@
-defmodule Tesla.Middleware.Telemetry do
-  @behaviour Tesla.Middleware
+if Code.ensure_loaded?(:telemetry) do
+  defmodule Tesla.Middleware.Telemetry do
+    @behaviour Tesla.Middleware
 
-  @moduledoc """
-  Send the request time and meta-information through telemetry.
+    @moduledoc """
+    Send the request time and meta-information through telemetry.
 
-  ### Example usage
-  ```
-  defmodule MyClient do
-    use Tesla
+    ### Example usage
+    ```
+    defmodule MyClient do
+      use Tesla
 
-    plug Tesla.Middleware.Telemetry
+      plug Tesla.Middleware.Telemetry
 
-  end
+    end
 
-  :telemetry.attach("my-tesla-telemetry", [:tesla, :request], fn event, time, meta, config ->
-    # Do something with the event
-  end)
-  ```
+    :telemetry.attach("my-tesla-telemetry", [:tesla, :request], fn event, time, meta, config ->
+      # Do something with the event
+    end)
+    ```
 
-  Please check the [telemetry](https://hexdocs.pm/telemetry/) for the further usage.
-  """
+    Please check the [telemetry](https://hexdocs.pm/telemetry/) for the further usage.
+    """
 
-  @doc false
-  def call(env, next, _opts) do
-    {time, res} = :timer.tc(Tesla, :run, [env, next])
-    :telemetry.execute([:tesla, :request], %{request_time: time}, %{result: res})
-    res
+    @doc false
+    def call(env, next, _opts) do
+      {time, res} = :timer.tc(Tesla, :run, [env, next])
+      :telemetry.execute([:tesla, :request], %{request_time: time}, %{result: res})
+      res
+    end
   end
 end


### PR DESCRIPTION
Fixes the warning about `:telemetry` not being in the app