### PR TITLE
Update Hex version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It embraces the concept of middleware when processing the request/response cycle
 
 ```elixir
 defp deps do
-  [{:tesla, "~> 1.2.1"}]
+  [{:tesla, "~> 1.3.0"}]
 end
 ```
 


### PR DESCRIPTION
Silly mistake on my part, but I blindly copied the `deps` example and spent a few minutes debugging why the Mint adapter wasn't working. Updating the README example for future blind copiers :)