### PR TITLE
add error handling to hackney adapter

### DIFF
--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -72,21 +72,23 @@ if Code.ensure_loaded?(:hackney) do
 
     defp request_stream(method, url, headers, body, opts) do
       with {:ok, ref} <- :hackney.request(method, url, headers, :stream, opts) do
-        res =
-          Enum.reduce_while(body, :ok, fn data, _ ->
-            case :hackney.send_body(ref, data) do
-              :ok -> {:cont, :ok}
-              error -> {:halt, error}
-            end
-          end)
-
-        case res do
+        case send_body(body ,ref) do
           :ok -> handle(:hackney.start_response(ref))
           error -> handle(error)
         end
       else
         e -> handle(e)
       end
+    end
+
+    defp send_body(body, ref) do
+      body
+      |> Enum.reduce_while(:ok, fn data, _ ->
+        case :hackney.send_body(ref, data) do
+          :ok -> {:cont, :ok}
+          error -> {:halt, error}
+        end
+      end)
     end
 
     defp handle({:error, _} = error), do: error

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -72,7 +72,14 @@ if Code.ensure_loaded?(:hackney) do
 
     defp request_stream(method, url, headers, body, opts) do
       with {:ok, ref} <- :hackney.request(method, url, headers, :stream, opts) do
-        for data <- body, do: :ok = :hackney.send_body(ref, data)
+        for data <- body do
+          with :ok <- :hackney.send_body(ref, data) do
+            :ok
+          else
+            e -> handle(e)
+          end
+        end
+
         handle(:hackney.start_response(ref))
       else
         e -> handle(e)


### PR DESCRIPTION
Now `:hackney.send_body/2` is wrapped with error handling
and will not crash with {:error, :closed} return (or any other than :ok)

This closes #314