### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It embraces the concept of middleware when processing the request/response cycle
   released version on Hex. See [the documentation](http://hexdocs.pm/tesla) for
   the documentation of the version you're using.
 
-<hr/>
+---
 
 ## [`0.x` to `1.0` Migration Guide](https://github.com/teamon/tesla/wiki/0.x-to-1.0-Migration-Guide)
 
@@ -26,7 +26,7 @@ end
 
 [Documentation for 0.x branch](https://github.com/teamon/tesla/tree/0.x)
 
-<hr/>
+---
 
 ## HTTP Client example
 
@@ -50,9 +50,15 @@ Then use it like this:
 
 ```elixir
 {:ok, response} = GitHub.user_repos("teamon")
-response.status  # => 200
-response.body    # => [%{…}, …]
-response.headers # => [{"content-type", "application/json"}, ...]
+
+response.status
+# => 200
+
+response.body
+# => [%{…}, …]
+
+response.headers
+# => [{"content-type", "application/json"}, ...]
 ```
 
 See below for documentation.
@@ -65,10 +71,15 @@ Add `tesla` as dependency in `mix.exs`:
 defp deps do
   [
     {:tesla, "~> 1.3.0"},
-    {:hackney, "~> 1.14.0"}, # optional, but recommended adapter
-    {:jason, ">= 1.0.0"} # optional, required by JSON middleware
+
+    # optional, but recommended adapter
+    {:hackney, "~> 1.14.0"},
+
+    # optional, required by JSON middleware
+    {:jason, ">= 1.0.0"}
   ]
 end
+
 ```
 
 Configure default adapter in `config/config.exs` (optional).
@@ -84,6 +95,7 @@ to use it in production environment as it does not validate SSL certificates
 [among other issues](https://github.com/teamon/tesla/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Ahttpc+).
 
 ## Documentation
+
 - [Middleware](#middleware)
 - [Runtime middleware](#runtime-middleware)
 - [Adapters](#adapters)
@@ -96,12 +108,13 @@ to use it in production environment as it does not validate SSL certificates
 - [Cookbook](https://github.com/teamon/tesla/wiki)
 - [Changelog](https://github.com/teamon/tesla/releases)
 
-
 ## Middleware
+
 Tesla is built around the concept of composable middlewares.
 This is very similar to how [Plug Router](https://github.com/elixir-plug/plug#the-plug-router) works.
 
-#### Basic
+### Basic
+
 - [`Tesla.Middleware.BaseUrl`](https://hexdocs.pm/tesla/Tesla.Middleware.BaseUrl.html) - set base url
 - [`Tesla.Middleware.Headers`](https://hexdocs.pm/tesla/Tesla.Middleware.Headers.html) - set request headers
 - [`Tesla.Middleware.Query`](https://hexdocs.pm/tesla/Tesla.Middleware.Query.html) - set query parameters
@@ -112,25 +125,27 @@ This is very similar to how [Plug Router](https://github.com/elixir-plug/plug#th
 - [`Tesla.Middleware.KeepRequest`](https://hexdocs.pm/tesla/Tesla.Middleware.KeepRequest.html) - keep request body & headers
 - [`Tesla.Middleware.PathParams`](https://hexdocs.pm/tesla/Tesla.Middleware.PathParams.html) - use templated URLs
 
-#### Formats
-- [`Tesla.Middleware.FormUrlencoded`](https://hexdocs.pm/tesla/Tesla.Middleware.FormUrlencoded.html) - urlencode POST body parameter, useful for POSTing a map/keyword list
+### Formats
+
+- [`Tesla.Middleware.FormUrlencoded`](https://hexdocs.pm/tesla/Tesla.Middleware.FormUrlencoded.html) - urlencode POST body, useful for POSTing a map/keyword list
 - [`Tesla.Middleware.JSON`](https://hexdocs.pm/tesla/Tesla.Middleware.JSON.html) - JSON request/response body
 - [`Tesla.Middleware.Compression`](https://hexdocs.pm/tesla/Tesla.Middleware.Compression.html) - gzip & deflate
 - [`Tesla.Middleware.DecodeRels`](https://hexdocs.pm/tesla/Tesla.Middleware.DecodeRels.html) - decode `Link` header into `opts[:rels]` field in response
 
-#### Auth
+### Auth
+
 - [`Tesla.Middleware.BasicAuth`](https://hexdocs.pm/tesla/Tesla.Middleware.BasicAuth.html) - HTTP Basic Auth
 - [`Tesla.Middleware.DigestAuth`](https://hexdocs.pm/tesla/Tesla.Middleware.DigestAuth.html) - Digest access authentication
 
-#### Error handling
+### Error handling
+
 - [`Tesla.Middleware.Timeout`](https://hexdocs.pm/tesla/Tesla.Middleware.Timeout.html) - timeout request after X milliseconds despite of server response
 - [`Tesla.Middleware.Retry`](https://hexdocs.pm/tesla/Tesla.Middleware.Retry.html) - retry few times in case of connection refused
 - [`Tesla.Middleware.Fuse`](https://hexdocs.pm/tesla/Tesla.Middleware.Fuse.html) - fuse circuit breaker integration
 
-
 ## Runtime middleware
 
-All HTTP functions (`get`, `post`, etc.) can take a dynamic client as the first parameter.
+All HTTP functions (`get`, `post`, etc.) can take a dynamic client as the first argument.
 This allow to use convenient syntax for modifying the behaviour in runtime.
 
 Consider the following case: GitHub API can be accessed using OAuth token authorization.
@@ -245,22 +260,20 @@ end
 
 Each piece of stream will be encoded as JSON and sent as a new line (conforming to JSON stream format)
 
-
-
-
 ## Multipart
 
 You can pass a `Tesla.Multipart` struct as the body.
-
 
 ```elixir
 alias Tesla.Multipart
 
 mp =
-  Multipart.new
+  Multipart.new()
   |> Multipart.add_content_type_param("charset=utf-8")
   |> Multipart.add_field("field1", "foo")
-  |> Multipart.add_field("field2", "bar", headers: [{"content-id", "1"}, {"content-type", "text/plain"}])
+  |> Multipart.add_field("field2", "bar",
+    headers: [{"content-id", "1"}, {"content-type", "text/plain"}]
+  )
   |> Multipart.add_file("test/tesla/multipart_test_file.sh")
   |> Multipart.add_file("test/tesla/multipart_test_file.sh", name: "foobar")
   |> Multipart.add_file_content("sample file content", "sample.txt")
@@ -282,7 +295,6 @@ config :tesla, MyApi, adapter: Tesla.Mock
 
 Then, mock requests before using your client:
 
-
 ```elixir
 defmodule MyAppTest do
   use ExUnit.Case
@@ -290,12 +302,13 @@ defmodule MyAppTest do
   import Tesla.Mock
 
   setup do
-    mock fn
+    mock(fn
       %{method: :get, url: "http://example.com/hello"} ->
         %Tesla.Env{status: 200, body: "hello"}
+
       %{method: :post, url: "http://example.com/world"} ->
         json(%{"my" => "data"})
-    end
+    end)
 
     :ok
   end
@@ -308,10 +321,9 @@ defmodule MyAppTest do
 end
 ```
 
-
 ## Writing middleware
 
-A Tesla middleware is a module with `call/3` function, that at some point calls `Tesla.run(env, next)` to process
+A Tesla middleware is a module with `c:Tesla.Middleware.call/3` function, that at some point calls `Tesla.run/2` with `env` and `next` to process
 the rest of stack.
 
 ```elixir
@@ -320,16 +332,17 @@ defmodule MyMiddleware do
 
   def call(env, next, options) do
     env
-    |> do_something_with_request
+    |> do_something_with_request()
     |> Tesla.run(next)
-    |> do_something_with_response
+    |> do_something_with_response()
   end
 end
 ```
 
 The arguments are:
+
 - `env` - `Tesla.Env` instance
-- `next` - middleware continuation stack; to be executed with `Tesla.run(env, next)`
+- `next` - middleware continuation stack; to be executed with `Tesla.run/2` with `env` and `next`
 - `options` - arguments passed during middleware configuration (`plug MyMiddleware, options`)
 
 There is no distinction between request and response middleware, it's all about executing `Tesla.run/2` function at the correct time.
@@ -341,8 +354,9 @@ defmodule Tesla.Middleware.RequestLogger do
   @behaviour Tesla.Middleware
 
   def call(env, next, _) do
-    IO.inspect env # print request env
-    Tesla.run(env, next)
+    env
+    |> IO.inspect()
+    |> Tesla.run(next)
   end
 end
 ```
@@ -354,9 +368,9 @@ defmodule Tesla.Middleware.ResponseLogger do
   @behaviour Tesla.Middleware
 
   def call(env, next, _) do
-    res = Tesla.run(env, next)
-    IO.inspect res # print response env
-    res
+    env
+    |> Tesla.run(next)
+    |> IO.inspect()
   end
 end
 ```
@@ -367,8 +381,6 @@ Middleware should have documentation following this template:
 
 ````elixir
 defmodule Tesla.Middleware.SomeMiddleware do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Short description what it does
 
@@ -376,6 +388,7 @@ defmodule Tesla.Middleware.SomeMiddleware do
 
 
   ### Example usage
+
   ```
   defmodule MyClient do
     use Tesla
@@ -385,12 +398,14 @@ defmodule Tesla.Middleware.SomeMiddleware do
   ```
 
   ### Options
+
   - `:list` - all possible options
   - `:with` - their default values
   """
+
+  @behaviour Tesla.Middleware
 end
 ````
-
 
 ## Direct usage
 
@@ -400,30 +415,36 @@ This however won’t include any middleware.
 ```elixir
 # Example get request
 {:ok, response} = Tesla.get("http://httpbin.org/ip")
-response.status   # => 200
-response.body     # => "{\n  "origin": "87.205.72.203"\n}\n"
-response.headers  # => [{"content-type", "application/json" ...}]
 
+response.status
+# => 200
+
+response.body
+# => "{\n  "origin": "87.205.72.203"\n}\n"
+
+response.headers
+# => [{"content-type", "application/json" ...}]
 
 {:ok, response} = Tesla.get("http://httpbin.org/get", query: [a: 1, b: "foo"])
-response.url     # => "http://httpbin.org/get?a=1&b=foo"
 
+response.url
+# => "http://httpbin.org/get?a=1&b=foo"
 
 # Example post request
-{:ok, response} = Tesla.post("http://httpbin.org/post", "data", headers: [{"content-type", "application/json"}])
+{:ok, response} =
+  Tesla.post("http://httpbin.org/post", "data", headers: [{"content-type", "application/json"}])
 ```
-
 
 ## Cheatsheet
 
+### Making requests 101
 
-#### Making requests 101
 ```elixir
 # GET /path
 get("/path")
 
 # GET /path?a=hi&b[]=1&b[]=2&b[]=3
-get("/path", query: [a: "hi", b: [1,2,3]])
+get("/path", query: [a: "hi", b: [1, 2, 3]])
 
 # GET with dynamic client
 get(client, "/path")
@@ -440,29 +461,33 @@ put("/path", "some-body-i-used-to-know", query: [a: "0"])
 patch("/path", multipart)
 ```
 
-#### Configuring HTTP functions visibility
+### Configuring HTTP functions visibility
+
 ```elixir
 # generate only get and post function
 use Tesla, only: ~w(get post)a
 
-# generate only delete fuction
+# generate only delete function
 use Tesla, only: [:delete]
 
 # generate all functions except delete and options
 use Tesla, except: [:delete, :options]
 ```
 
-#### Disable docs for HTTP functions
+### Disable docs for HTTP functions
+
 ```elixir
 use Tesla, docs: false
 ```
 
-#### Decode only JSON response (do not encode request)
+### Decode only JSON response (do not encode request)
+
 ```elixir
 plug Tesla.Middleware.DecodeJson
 ```
 
-#### Use other JSON library
+### Use other JSON library
+
 ```elixir
 # use JSX
 plug Tesla.Middleware.JSON, engine: JSX, engine_opts: [strict: [:comments]]
@@ -471,15 +496,15 @@ plug Tesla.Middleware.JSON, engine: JSX, engine_opts: [strict: [:comments]]
 plug Tesla.Middleware.JSON, decode: &JSX.decode/1, encode: &JSX.encode/1
 ```
 
+### Custom middleware
 
-#### Custom middleware
 ```elixir
 defmodule Tesla.Middleware.MyCustomMiddleware do
   def call(env, next, options) do
     env
-    |> do_something_with_request
+    |> do_something_with_request()
     |> Tesla.run(next)
-    |> do_something_with_response
+    |> do_something_with_response()
   end
 end
 ```

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -1,51 +1,60 @@
 if Code.ensure_loaded?(:gun) do
   defmodule Tesla.Adapter.Gun do
     @moduledoc """
-    Adapter for [gun](https://github.com/ninenines/gun)
+    Adapter for [gun](https://github.com/ninenines/gun).
+
     Remember to add `{:gun, "~> 1.3"}` to dependencies.
     In version 1.3 gun sends `host` header with port. Fixed in master branch.
     Also, you need to recompile tesla after adding `:gun` dependency:
+
     ```
     mix deps.clean tesla
     mix deps.compile tesla
     ```
-    ### Example usage
+
+    ## Example usage
+
     ```
     # set globally in config/config.exs
     config :tesla, :adapter, Tesla.Adapter.Gun
+
     # set per module
     defmodule MyClient do
       use Tesla
       adapter Tesla.Adapter.Gun
     end
     ```
-    ### Adapter specific options:
-    * `timeout` - Time, while process, will wait for gun messages.
-    * `body_as` - What will be returned in `%Tesla.Env{}` body key. Possible values - `:plain`, `:stream`, `:chunks`. Defaults to `:plain`.
-        * `:plain` - as binary.
-        * `:stream` - as stream. If you don't want to close connection (because you want to reuse it later) pass `close_conn: false` in adapter opts.
-        * `:chunks` - as chunks. You can get response body in chunks using `Tesla.Adapter.Gun.read_chunk/3` function.
+
+    ## Adapter specific options
+
+    - `:timeout` - Time, while process, will wait for gun messages.
+    - `:body_as` - What will be returned in `%Tesla.Env{}` body key. Possible values - `:plain`, `:stream`, `:chunks`. Defaults to `:plain`.
+        - `:plain` - as binary.
+        - `:stream` - as stream. If you don't want to close connection (because you want to reuse it later) pass `close_conn: false` in adapter opts.
+        - `:chunks` - as chunks. You can get response body in chunks using `Tesla.Adapter.Gun.read_chunk/3` function.
         Processing of the chunks and checking body size must be done by yourself. Example of processing function is in `test/tesla/adapter/gun_test.exs` - `Tesla.Adapter.GunTest.read_body/4`. If you don't need connection later don't forget to close it with `Tesla.Adapter.Gun.close/1`.
-    * `max_body` - Max response body size in bytes. Works only with `body_as: :plain`, with other settings you need to check response body size by yourself.
-    * `conn` - Opened connection pid with gun. Is used for reusing gun connections.
-    * `original` - Original host with port, for which reused connection was open. Needed for `Tesla.Middleware.FollowRedirects`. Otherwise adapter will use connection for another open host. Example: `"example.com:80"`.
-    * `close_conn` - Close connection or not after receiving full response body. Is used for reusing gun connections. Defaults to `true`.
-    * `certificates_verification` - Add SSL certificates verification. [erlang-certifi](https://github.com/certifi/erlang-certifi) [ssl_verify_fun.erl](https://github.com/deadtrickster/ssl_verify_fun.erl)
-    * `proxy` - Proxy for requests. **Socks proxy are supported only for gun master branch**. Examples: `{'localhost', 1234}`, `{{127, 0, 0, 1}, 1234}`, `{:socks5, 'localhost', 1234}`.
-    ### [Gun options](https://ninenines.eu/docs/en/gun/1.3/manual/gun/):
-    * `connect_timeout` - Connection timeout.
-    * `http_opts` - Options specific to the HTTP protocol.
-    * `http2_opts` -  Options specific to the HTTP/2 protocol.
-    * `protocols` - Ordered list of preferred protocols. Defaults: [http2, http] - for :tls, [http] - for :tcp.
-    * `trace` - Whether to enable dbg tracing of the connection process. Should only be used during debugging. Default: false.
-    * `transport` - Whether to use TLS or plain TCP. The default varies depending on the port used. Port 443 defaults to tls. All other ports default to tcp.
-    * `transport_opts` - Transport options. They are TCP options or TLS options depending on the selected transport. Default: []. Gun version: 1.3
-    * `tls_opts` - TLS transport options. Default: []. Gun from master branch.
-    * `tcp_opts` - TCP trasnport options. Default: []. Gun from master branch.
-    * `socks_opts` - Options for socks. Default: []. Gun from master branch.
-    * `ws_opts` - Options specific to the Websocket protocol. Default: %{}.
-        * `compress` - Whether to enable permessage-deflate compression. This does not guarantee that compression will be used as it is the server that ultimately decides. Defaults to false.
-        * `protocols` - A non-empty list enables Websocket protocol negotiation. The list of protocols will be sent in the sec-websocket-protocol request header. The handler module interface is currently undocumented and must be set to `gun_ws_h`.
+    - `:max_body` - Max response body size in bytes. Works only with `body_as: :plain`, with other settings you need to check response body size by yourself.
+    - `:conn` - Opened connection pid with gun. Is used for reusing gun connections.
+    - `:original` - Original host with port, for which reused connection was open. Needed for `Tesla.Middleware.FollowRedirects`. Otherwise adapter will use connection for another open host. Example: `"example.com:80"`.
+    - `:close_conn` - Close connection or not after receiving full response body. Is used for reusing gun connections. Defaults to `true`.
+    - `:certificates_verification` - Add SSL certificates verification. [erlang-certifi](https://github.com/certifi/erlang-certifi) [ssl_verify_fun.erl](https://github.com/deadtrickster/ssl_verify_fun.erl)
+    - `:proxy` - Proxy for requests. **Socks proxy are supported only for gun master branch**. Examples: `{'localhost', 1234}`, `{{127, 0, 0, 1}, 1234}`, `{:socks5, 'localhost', 1234}`.
+
+    ## [Gun options](https://ninenines.eu/docs/en/gun/1.3/manual/gun/)
+
+    - `:connect_timeout` - Connection timeout.
+    - `:http_opts` - Options specific to the HTTP protocol.
+    - `:http2_opts` -  Options specific to the HTTP/2 protocol.
+    - `:protocols` - Ordered list of preferred protocols. Defaults: `[:http2, :http]`- for :tls, `[:http]` - for :tcp.
+    - `:trace` - Whether to enable dbg tracing of the connection process. Should only be used during debugging. Default: false.
+    - `:transport` - Whether to use TLS or plain TCP. The default varies depending on the port used. Port 443 defaults to tls. All other ports default to tcp.
+    - `:transport_opts` - Transport options. They are TCP options or TLS options depending on the selected transport. Default: `[]`. Gun version: 1.3
+    - `:tls_opts` - TLS transport options. Default: `[]`. Gun from master branch.
+    - `:tcp_opts` - TCP trasnport options. Default: `[]`. Gun from master branch.
+    - `:socks_opts` - Options for socks. Default: `[]`. Gun from master branch.
+    - `:ws_opts` - Options specific to the Websocket protocol. Default: `%{}`.
+        - `:compress` - Whether to enable permessage-deflate compression. This does not guarantee that compression will be used as it is the server that ultimately decides. Defaults to false.
+        - `:protocols` - A non-empty list enables Websocket protocol negotiation. The list of protocols will be sent in the sec-websocket-protocol request header. The handler module interface is currently undocumented and must be set to `gun_ws_h`.
     """
     @behaviour Tesla.Adapter
     alias Tesla.Multipart
@@ -65,8 +74,7 @@ if Code.ensure_loaded?(:gun) do
 
     @adapter_default_timeout 1_000
 
-    @impl true
-    @doc false
+    @impl Tesla.Adapter
     def call(env, opts) do
       with {:ok, status, headers, body} <- request(env, opts) do
         {:ok, %{env | status: status, headers: format_headers(headers), body: body}}
@@ -75,6 +83,7 @@ if Code.ensure_loaded?(:gun) do
 
     @doc """
     Reads chunk of the response body.
+
     Returns `{:fin, binary()}` if all body received, otherwise returns `{:nofin, binary()}`.
     """
     @spec read_chunk(pid(), reference(), keyword() | map()) ::
@@ -98,7 +107,7 @@ if Code.ensure_loaded?(:gun) do
     end
 
     @doc """
-    Brutally close the `gun` connection
+    Brutally close the `gun` connection.
     """
     @spec close(pid()) :: :ok
     defdelegate close(pid), to: :gun

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -1,7 +1,7 @@
 if Code.ensure_loaded?(:hackney) do
   defmodule Tesla.Adapter.Hackney do
     @moduledoc """
-    Adapter for [hackney](https://github.com/benoitc/hackney)
+    Adapter for [hackney](https://github.com/benoitc/hackney).
 
     Remember to add `{:hackney, "~> 1.13"}` to dependencies (and `:hackney` to applications in `mix.exs`)
     Also, you need to recompile tesla after adding `:hackney` dependency:
@@ -11,7 +11,8 @@ if Code.ensure_loaded?(:hackney) do
     mix deps.compile tesla
     ```
 
-    ### Example usage
+    ## Example usage
+
     ```
     # set globally in config/config.exs
     config :tesla, :adapter, Tesla.Adapter.Hackney
@@ -27,7 +28,7 @@ if Code.ensure_loaded?(:hackney) do
     @behaviour Tesla.Adapter
     alias Tesla.Multipart
 
-    @doc false
+    @impl Tesla.Adapter
     def call(env, opts) do
       with {:ok, status, headers, body} <- request(env, opts) do
         {:ok, %{env | status: status, headers: format_headers(headers), body: format_body(body)}}

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -1,6 +1,6 @@
 defmodule Tesla.Adapter.Httpc do
   @moduledoc """
-  Adapter for [httpc](http://erlang.org/doc/man/httpc.html)
+  Adapter for [httpc](http://erlang.org/doc/man/httpc.html).
 
   This is the default adapter.
 
@@ -15,7 +15,7 @@ defmodule Tesla.Adapter.Httpc do
   @override_defaults autoredirect: false
   @http_opts ~w(timeout connect_timeout ssl essl autoredirect proxy_auth version relaxed url_encode)a
 
-  @doc false
+  @impl Tesla.Adapter
   def call(env, opts) do
     opts = Tesla.Adapter.opts(@override_defaults, env, opts)
 

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -1,7 +1,7 @@
 if Code.ensure_loaded?(:ibrowse) do
   defmodule Tesla.Adapter.Ibrowse do
     @moduledoc """
-    Adapter for [ibrowse](https://github.com/cmullaparthi/ibrowse)
+    Adapter for [ibrowse](https://github.com/cmullaparthi/ibrowse).
 
     Remember to add `{:ibrowse, "~> 4.2"}` to dependencies (and `:ibrowse` to applications in `mix.exs`)
     Also, you need to recompile tesla after adding `:ibrowse` dependency:
@@ -11,7 +11,8 @@ if Code.ensure_loaded?(:ibrowse) do
     mix deps.compile tesla
     ```
 
-    ### Example usage
+    ## Example usage
+
     ```
     # set globally in config/config.exs
     config :tesla, :adapter, Tesla.Adapter.Ibrowse
@@ -29,7 +30,7 @@ if Code.ensure_loaded?(:ibrowse) do
     import Tesla.Adapter.Shared, only: [stream_to_fun: 1, next_chunk: 1]
     alias Tesla.Multipart
 
-    @doc false
+    @impl Tesla.Adapter
     def call(env, opts) do
       with {:ok, status, headers, body} <- request(env, opts) do
         {:ok,

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -1,17 +1,20 @@
 if Code.ensure_loaded?(Mint.HTTP) do
   defmodule Tesla.Adapter.Mint do
     @moduledoc """
-    Adapter for [mint](https://github.com/elixir-mint/mint)
+    Adapter for [mint](https://github.com/elixir-mint/mint).
 
     Caution: The minimum supported Elixir version for mint is 1.5.0
 
     Remember to add `{:mint, "~> 1.0"}` and `{:castore, "~> 0.1"}` to dependencies
     Also, you need to recompile tesla after adding `:mint` dependency:
+
     ```
     mix deps.clean tesla
     mix deps.compile tesla
     ```
-    ### Example usage
+
+    ## Example usage
+
     ```
     # set globally in config/config.exs
     config :tesla, :adapter, Tesla.Adapter.Mint
@@ -23,27 +26,31 @@ if Code.ensure_loaded?(Mint.HTTP) do
     # set global custom cacertfile
     config :tesla, Tesla.Adapter.Mint, cacert: ["path_to_cacert"]
     ```
-    ### Adapter specific options:
-    * `timeout` - Time, while process, will wait for mint messages.
-    * `body_as` - What will be returned in `%Tesla.Env{}` body key. Possible values - `:plain`, `:stream`, `:chunks`. Defaults to `:plain`.
-      * `:plain` - as binary.
-      * `:stream` - as stream. If you don't want to close connection (because you want to reuse it later) pass `close_conn: false` in adapter opts.
-      * `:chunks` - as chunks. You can get response body in chunks using `Tesla.Adapter.Mint.read_chunk/3` function.
+
+    ## Adapter specific options:
+
+    - `:timeout` - Time, while process, will wait for mint messages.
+    - `:body_as` - What will be returned in `%Tesla.Env{}` body key. Possible values - `:plain`, `:stream`, `:chunks`. Defaults to `:plain`.
+      - `:plain` - as binary.
+      - `:stream` - as stream. If you don't want to close connection (because you want to reuse it later) pass `close_conn: false` in adapter opts.
+      - `:chunks` - as chunks. You can get response body in chunks using `Tesla.Adapter.Mint.read_chunk/3` function.
       Processing of the chunks and checking body size must be done by yourself. Example of processing function is in `test/tesla/adapter/mint_test.exs` - `Tesla.Adapter.MintTest.read_body/4`. If you don't need connection later don't forget to close it with `Tesla.Adapter.Mint.close/1`.
-    * `max_body` - Max response body size in bytes. Works only with `body_as: :plain`, with other settings you need to check response body size by yourself.
-    * `conn` - Opened connection with mint. Is used for reusing mint connections.
-    * `original` - Original host with port, for which reused connection was open. Needed for `Tesla.Middleware.FollowRedirects`. Otherwise adapter will use connection for another open host.
-    * `close_conn` - Close connection or not after receiving full response body. Is used for reusing mint connections. Defaults to `true`.
-    * `proxy` - Proxy settings. E.g.: `{:http, "localhost", 8888, []}`, `{:http, "127.0.0.1", 8888, []}`
+    - `:max_body` - Max response body size in bytes. Works only with `body_as: :plain`, with other settings you need to check response body size by yourself.
+    - `:conn` - Opened connection with mint. Is used for reusing mint connections.
+    - `:original` - Original host with port, for which reused connection was open. Needed for `Tesla.Middleware.FollowRedirects`. Otherwise adapter will use connection for another open host.
+    - `:close_conn` - Close connection or not after receiving full response body. Is used for reusing mint connections. Defaults to `true`.
+    - `:proxy` - Proxy settings. E.g.: `{:http, "localhost", 8888, []}`, `{:http, "127.0.0.1", 8888, []}`
     """
+
     @behaviour Tesla.Adapter
+
     import Tesla.Adapter.Shared
     alias Tesla.Multipart
     alias Mint.HTTP
 
     @default timeout: 2_000, body_as: :plain, close_conn: true, mode: :active
 
-    @impl true
+    @impl Tesla.Adapter
     def call(env, opts) do
       opts = Tesla.Adapter.opts(@default, env, opts)
 

--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -20,29 +20,26 @@ defmodule Tesla.Builder do
 
       if unquote(docs) do
         @doc """
-        Perform a request
+        Perform a request.
 
-        Options:
-        - `:method`   - the request method, one of [:head, :get, :delete, :trace, :options, :post, :put, :patch]
-        - `:url`      - either full url e.g. "http://example.com/some/path" or just "/some/path" if using `Tesla.Middleware.BaseUrl`
-        - `:query`    - a keyword list of query params, e.g. `[page: 1, per_page: 100]`
-        - `:headers`  - a keyworld list of headers, e.g. `[{"content-type", "text/plain"}]`
-        - `:body`     - depends on used middleware:
+        ## Options
+
+        - `:method` - the request method, one of [:head, :get, :delete, :trace, :options, :post, :put, :patch]
+        - `:url` - either full url e.g. "http://example.com/some/path" or just "/some/path" if using `Tesla.Middleware.BaseUrl`
+        - `:query` - a keyword list of query params, e.g. `[page: 1, per_page: 100]`
+        - `:headers` - a keyworld list of headers, e.g. `[{"content-type", "text/plain"}]`
+        - `:body` - depends on used middleware:
             - by default it can be a binary
             - if using e.g. JSON encoding middleware it can be a nested map
             - if adapter supports it it can be a Stream with any of the above
-        - `:opts`     - custom, per-request middleware or adapter options
+        - `:opts` - custom, per-request middleware or adapter options
 
-        Examples:
+        ## Examples
 
             ExampleApi.request(method: :get, url: "/users/path")
 
-        You can also use shortcut methods like:
-
+            # use shortcut methods
             ExampleApi.get("/users/1")
-
-        or
-
             ExampleApi.post(client, "/users", %{name: "Jon"})
         """
       else
@@ -79,7 +76,7 @@ defmodule Tesla.Builder do
   end
 
   @doc """
-  Attach middleware to your API client
+  Attach middleware to your API client.
 
   ```
   defmodule ExampleApi do
@@ -115,7 +112,7 @@ defmodule Tesla.Builder do
   end
 
   @doc """
-  Choose adapter for your API client
+  Choose adapter for your API client.
 
   ```
   defmodule ExampleApi do

--- a/lib/tesla/middleware/basic_auth.ex
+++ b/lib/tesla/middleware/basic_auth.ex
@@ -1,12 +1,11 @@
 defmodule Tesla.Middleware.BasicAuth do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
-  Basic authentication middleware
+  Basic authentication middleware.
 
   [Wiki on the topic](https://en.wikipedia.org/wiki/Basic_access_authentication)
 
-  ### Example
+  ## Example
+
   ```
   defmodule MyClient do
     use Tesla
@@ -23,12 +22,15 @@ defmodule Tesla.Middleware.BasicAuth do
   end
   ```
 
-  ### Options
-  - `:username`  - username (defaults to `""`)
-  - `:password`  - password (defaults to `""`)
+  ## Options
+
+  - `:username` - username (defaults to `""`)
+  - `:password` - password (defaults to `""`)
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     opts = opts || %{}
 

--- a/lib/tesla/middleware/compression.ex
+++ b/lib/tesla/middleware/compression.ex
@@ -1,12 +1,11 @@
 defmodule Tesla.Middleware.Compression do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Compress requests and decompress responses.
 
   Supports "gzip" and "deflate" encodings using erlang's built-in `:zlib` module.
 
-  ### Example usage
+  ## Example usage
+
   ```
   defmodule MyClient do
     use Tesla
@@ -15,11 +14,14 @@ defmodule Tesla.Middleware.Compression do
   end
   ```
 
-  ### Options
+  ## Options
+
   - `:format` - request compression format, `"gzip"` (default) or `"deflate"`
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     env
     |> compress(opts)
@@ -30,7 +32,9 @@ defmodule Tesla.Middleware.Compression do
   defp compressable?(body), do: is_binary(body)
 
   @doc """
-  Compress request, used by `Tesla.Middleware.CompressRequest`
+  Compress request.
+
+  It is used by `Tesla.Middleware.CompressRequest`.
   """
   def compress(env, opts) do
     if compressable?(env.body) do
@@ -48,7 +52,9 @@ defmodule Tesla.Middleware.Compression do
   defp compress_body(body, "deflate"), do: :zlib.zip(body)
 
   @doc """
-  Decompress response, used by `Tesla.Middleware.DecompressResponse`
+  Decompress response.
+
+  It is used by `Tesla.Middleware.DecompressResponse`.
   """
   def decompress({:ok, env}), do: {:ok, decompress(env)}
   def decompress({:error, reasonn}), do: {:error, reasonn}
@@ -64,15 +70,15 @@ defmodule Tesla.Middleware.Compression do
 end
 
 defmodule Tesla.Middleware.CompressRequest do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Only compress request.
 
   See `Tesla.Middleware.Compression` for options.
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     env
     |> Tesla.Middleware.Compression.compress(opts)
@@ -81,15 +87,15 @@ defmodule Tesla.Middleware.CompressRequest do
 end
 
 defmodule Tesla.Middleware.DecompressResponse do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Only decompress response.
 
   See `Tesla.Middleware.Compression` for options.
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, _opts) do
     env
     |> Tesla.run(next)

--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -1,13 +1,12 @@
 defmodule Tesla.Middleware.BaseUrl do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Set base URL for all requests.
 
   The base URL will be prepended to request path/url only
   if it does not include http(s).
 
-  ### Example usage
+  ## Example usage
+
   ```
   defmodule MyClient do
     use Tesla
@@ -22,7 +21,9 @@ defmodule Tesla.Middleware.BaseUrl do
   ```
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, base) do
     env
     |> apply_base(base)
@@ -51,12 +52,11 @@ defmodule Tesla.Middleware.BaseUrl do
 end
 
 defmodule Tesla.Middleware.Headers do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Set default headers for all requests
 
-  ### Example usage
+  ## Example usage
+
   ```
   defmodule Myclient do
     use Tesla
@@ -65,7 +65,10 @@ defmodule Tesla.Middleware.Headers do
   end
   ```
   """
-  @doc false
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, headers) do
     env
     |> Tesla.put_headers(headers)
@@ -74,12 +77,11 @@ defmodule Tesla.Middleware.Headers do
 end
 
 defmodule Tesla.Middleware.Query do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Set default query params for all requests
 
-  ### Example usage
+  ## Example usage
+
   ```
   defmodule Myclient do
     use Tesla
@@ -88,7 +90,10 @@ defmodule Tesla.Middleware.Query do
   end
   ```
   """
-  @doc false
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, query) do
     env
     |> merge(query)
@@ -103,12 +108,11 @@ defmodule Tesla.Middleware.Query do
 end
 
 defmodule Tesla.Middleware.Opts do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
-  Set default opts for all requests
+  Set default opts for all requests.
 
-  ### Example usage
+  ## Example usage
+
   ```
   defmodule Myclient do
     use Tesla
@@ -117,7 +121,10 @@ defmodule Tesla.Middleware.Opts do
   end
   ```
   """
-  @doc false
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     Tesla.run(%{env | opts: env.opts ++ opts}, next)
   end

--- a/lib/tesla/middleware/decode_rels.ex
+++ b/lib/tesla/middleware/decode_rels.ex
@@ -1,11 +1,9 @@
 defmodule Tesla.Middleware.DecodeRels do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Decode `Link` Hypermedia HTTP header into `opts[:rels]` field in response.
 
+  ## Example usage
 
-  ### Example usage
   ```
   defmodule MyClient do
     use Tesla
@@ -14,12 +12,15 @@ defmodule Tesla.Middleware.DecodeRels do
   end
 
   env = MyClient.get("/...")
-  env.opts[:rels] # => %{"Next" => "http://...", "Prev" => "..."}
-  ```
 
+  env.opts[:rels]
+  # => %{"Next" => "http://...", "Prev" => "..."}
+  ```
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, _opts) do
     env
     |> Tesla.run(next)

--- a/lib/tesla/middleware/digest_auth.ex
+++ b/lib/tesla/middleware/digest_auth.ex
@@ -1,6 +1,4 @@
 defmodule Tesla.Middleware.DigestAuth do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Digest access authentication middleware
 
@@ -9,27 +7,30 @@ defmodule Tesla.Middleware.DigestAuth do
   **NOTE**: Currently the implementation is incomplete and works only for MD5 algorithm
   and auth qop.
 
-  ### Example
+  ## Example
+
   ```
   defmodule MyClient do
     use Tesla
 
     def client(username, password, opts \\ %{}) do
-      Tesla.client [
+      Tesla.client([
         {Tesla.Middleware.DigestAuth, Map.merge(%{username: username, password: password}, opts)}
-      ]
+      ])
     end
   end
   ```
 
-  ### Options
-  - `:username`  - username (defaults to `""`)
-  - `:password`  - password (defaults to `""`)
+  ## Options
+  - `:username` - username (defaults to `""`)
+  - `:password` - password (defaults to `""`)
   - `:cnonce_fn` - custom function generating client nonce (defaults to `&Tesla.Middleware.DigestAuth.cnonce/0`)
-  - `:nc`        - nonce counter (defaults to `"00000000"`)
+  - `:nc` - nonce counter (defaults to `"00000000"`)
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     if env.opts && Keyword.get(env.opts, :digest_auth_handshake) do
       Tesla.run(env, next)

--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -1,10 +1,9 @@
 defmodule Tesla.Middleware.FollowRedirects do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Follow 3xx redirects
 
-  ### Example
+  ## Example
+
   ```
   defmodule MyClient do
     use Tesla
@@ -13,15 +12,17 @@ defmodule Tesla.Middleware.FollowRedirects do
   end
   ```
 
-  ### Options
-  - `:max_redirects` - limit number of redirects (default: `5`)
+  ## Options
 
+  - `:max_redirects` - limit number of redirects (default: `5`)
   """
+
+  @behaviour Tesla.Middleware
 
   @max_redirects 5
   @redirect_statuses [301, 302, 303, 307, 308]
 
-  @doc false
+  @impl Tesla.Middleware
   def call(env, next, opts \\ []) do
     max = Keyword.get(opts || [], :max_redirects, @max_redirects)
 

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -1,16 +1,16 @@
 defmodule Tesla.Middleware.FormUrlencoded do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Send request body as `application/x-www-form-urlencoded`.
+
   Performs encoding of `body` from a `Map` such as `%{"foo" => "bar"}` into
   url encoded data.
+
   Performs decoding of the response into a map when urlencoded and content-type
   is `application/x-www-form-urlencoded`, so `"foo=bar"` becomes
   `%{"foo" => "bar"}`.
 
+  ## Example usage
 
-  ### Example usage
   ```
   defmodule Myclient do
     use Tesla
@@ -21,11 +21,13 @@ defmodule Tesla.Middleware.FormUrlencoded do
   Myclient.post("/url", %{key: :value})
   ```
 
-  ### Options
+  ## Options
+
   - `:decode` - decoding function, defaults to `URI.decode_query/1`
   - `:encode` - encoding function, defaults to `URI.encode_query/1`
 
-  ### Nested Maps
+  ## Nested Maps
+
   Natively, nested maps are not supported in the body, so
   `%{"foo" => %{"bar" => "baz"}}` won't be encoded and raise an error.
   Support for this specific case is obtained by configuring the middleware to
@@ -41,11 +43,14 @@ defmodule Tesla.Middleware.FormUrlencoded do
   end
 
   Myclient.post("/url", %{key: %{nested: "value"}})
+  ```
   """
+
+  @behaviour Tesla.Middleware
 
   @content_type "application/x-www-form-urlencoded"
 
-  @doc false
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     env
     |> encode(opts)

--- a/lib/tesla/middleware/fuse.ex
+++ b/lib/tesla/middleware/fuse.ex
@@ -1,7 +1,5 @@
 if Code.ensure_loaded?(:fuse) do
   defmodule Tesla.Middleware.Fuse do
-    @behaviour Tesla.Middleware
-
     @moduledoc """
     Circuit Breaker middleware using [fuse](https://github.com/jlouis/fuse)
 
@@ -13,7 +11,8 @@ if Code.ensure_loaded?(:fuse) do
     mix deps.compile tesla
     ```
 
-    ### Example usage
+    ## Example usage
+
     ```
     defmodule MyClient do
       use Tesla
@@ -22,11 +21,12 @@ if Code.ensure_loaded?(:fuse) do
     end
     ```
 
-    ### Options
+    ## Options
+
     - `:name` - fuse name (defaults to module name)
     - `:opts` - fuse options (see fuse docs for reference)
 
-    ### SASL logger
+    ## SASL logger
 
     fuse library uses [SASL (System Architecture Support Libraries)](http://erlang.org/doc/man/sasl_app.html).
 
@@ -39,11 +39,13 @@ if Code.ensure_loaded?(:fuse) do
     Read more at [jlouis/fuse#32](https://github.com/jlouis/fuse/issues/32) and [jlouis/fuse#19](https://github.com/jlouis/fuse/issues/19).
     """
 
+    @behaviour Tesla.Middleware
+
     # options borrowed from http://blog.rokkincat.com/circuit-breakers-in-elixir/
     # most probably not valid for your use case
     @defaults {{:standard, 2, 10_000}, {:reset, 60_000}}
 
-    @doc false
+    @impl Tesla.Middleware
     def call(env, next, opts) do
       opts = opts || []
       name = Keyword.get(opts, :name, env.__module__)

--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -1,6 +1,4 @@
 defmodule Tesla.Middleware.JSON do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Encode requests and decode responses as JSON.
 
@@ -14,8 +12,8 @@ defmodule Tesla.Middleware.JSON do
   mix deps.compile tesla
   ```
 
+  ## Example usage
 
-  ### Example usage
   ```
   defmodule MyClient do
     use Tesla
@@ -30,7 +28,8 @@ defmodule Tesla.Middleware.JSON do
   end
   ```
 
-  ### Options
+  ## Options
+
   - `:decode` - decoding function
   - `:encode` - encoding function
   - `:encode_content_type` - content-type to be used in request header
@@ -39,13 +38,15 @@ defmodule Tesla.Middleware.JSON do
   - `:decode_content_types` - list of additional decodable content-types
   """
 
+  @behaviour Tesla.Middleware
+
   # NOTE: text/javascript added to support Facebook Graph API.
   #       see https://github.com/teamon/tesla/pull/13
   @default_content_types ["application/json", "text/javascript"]
   @default_encode_content_type "application/json"
   @default_engine Jason
 
-  @doc false
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     opts = opts || []
 
@@ -56,7 +57,9 @@ defmodule Tesla.Middleware.JSON do
   end
 
   @doc """
-  Encode request body as JSON. Used by `Tesla.Middleware.EncodeJson`
+  Encode request body as JSON.
+
+  It is used by `Tesla.Middleware.EncodeJson`.
   """
   def encode(env, opts) do
     with true <- encodable?(env),
@@ -91,7 +94,9 @@ defmodule Tesla.Middleware.JSON do
   defp encodable?(_), do: true
 
   @doc """
-  Decode response body as JSON. Used by `Tesla.Middleware.DecodeJson`
+  Decode response body as JSON.
+
+  It is used by `Tesla.Middleware.DecodeJson`.
   """
   def decode(env, opts) do
     with true <- decodable?(env, opts),

--- a/lib/tesla/middleware/keep_request.ex
+++ b/lib/tesla/middleware/keep_request.ex
@@ -1,10 +1,9 @@
 defmodule Tesla.Middleware.KeepRequest do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Store request body & headers into opts.
 
-  ### Example
+  ## Example
+
   ```
   defmodule MyClient do
     use Tesla
@@ -13,12 +12,21 @@ defmodule Tesla.Middleware.KeepRequest do
   end
 
   {:ok, env} = MyClient.post("/", "request-data")
-  env.body # => "response-data"
-  env.opts[:req_body] # => "request-data"
-  env.opts[:req_headers] # => [{"request-headers", "are-safe"}, ...]
+
+  env.body
+  # => "response-data"
+
+  env.opts[:req_body]
+  # => "request-data"
+
+  env.opts[:req_headers]
+  # => [{"request-headers", "are-safe"}, ...]
   ```
   """
-  @doc false
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, _opts) do
     env
     |> Tesla.put_opt(:req_body, env.body)

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -36,14 +36,12 @@ defmodule Tesla.Middleware.Logger.Formatter do
 end
 
 defmodule Tesla.Middleware.Logger do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Log requests using Elixir's Logger.
 
   With the default settings it logs request method, url, response status and time taken in milliseconds.
 
-  ### Example usage
+  ## Example usage
   ```
   defmodule MyClient do
     use Tesla
@@ -52,7 +50,7 @@ defmodule Tesla.Middleware.Logger do
   end
   ```
 
-  ### Options
+  ## Options
   - `:log_level` - custom function for calculating log level (see below)
   - `:filter_headers` - sanitizes sensitive headers before logging in debug mode (see below)
 
@@ -95,7 +93,7 @@ defmodule Tesla.Middleware.Logger do
   end
   ```
 
-  ### Logger Debug output
+  ## Logger Debug output
 
   When the Elixir Logger log level is set to `:debug`
   Tesla Logger will show full request & response.
@@ -108,7 +106,7 @@ defmodule Tesla.Middleware.Logger do
   # config/dev.local.exs
   config :tesla, Tesla.Middleware.Logger, debug: false
   ```
-  #### Filter headers
+  ### Filter headers
 
   To sanitize sensitive headers such as `authorization` in
   debug logs, add them to the `:filter_headers` option.
@@ -121,6 +119,8 @@ defmodule Tesla.Middleware.Logger do
   ```
   """
 
+  @behaviour Tesla.Middleware
+
   alias Tesla.Middleware.Logger.Formatter
 
   @config Application.get_env(:tesla, __MODULE__, [])
@@ -130,7 +130,7 @@ defmodule Tesla.Middleware.Logger do
 
   require Logger
 
-  @doc false
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     {time, response} = :timer.tc(Tesla, :run, [env, next])
     level = log_level(response, opts)

--- a/lib/tesla/middleware/method_override.ex
+++ b/lib/tesla/middleware/method_override.ex
@@ -1,13 +1,12 @@
 defmodule Tesla.Middleware.MethodOverride do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Middleware that adds X-Http-Method-Override header with original request
   method and sends the request as post.
 
   Useful when there's an issue with sending non-post request.
 
-  ### Example
+  ## Example
+
   ```
   defmodule MyClient do
     use Tesla
@@ -16,12 +15,15 @@ defmodule Tesla.Middleware.MethodOverride do
   end
   ```
 
-  ### Options
+  ## Options
+
   - `:override` - list of http methods that should be overriden,
   everything except `:get` and `:post` if not specified
   """
 
-  @doc false
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     if overridable?(env, opts) do
       env

--- a/lib/tesla/middleware/path_params.ex
+++ b/lib/tesla/middleware/path_params.ex
@@ -1,13 +1,11 @@
 defmodule Tesla.Middleware.PathParams do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Use templated URLs with separate params.
 
   Useful when logging or reporting metric per URL.
 
+  ## Example usage
 
-  ### Example usage
   ```
   defmodule MyClient do
     use Tesla
@@ -24,10 +22,11 @@ defmodule Tesla.Middleware.PathParams do
   ```
   """
 
+  @behaviour Tesla.Middleware
+
   @rx ~r/:([\w_]+)/
 
-  @doc false
-  @impl true
+  @impl Tesla.Middleware
   def call(env, next, _) do
     url = build_url(env.url, env.opts[:path_params])
     Tesla.run(%{env | url: url}, next)

--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -1,6 +1,4 @@
 defmodule Tesla.Middleware.Retry do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Retry using exponential backoff and full jitter. This middleware only retries in the
   case of connection errors (`nxdomain`, `connrefused` etc). Application error
@@ -21,7 +19,8 @@ defmodule Tesla.Middleware.Retry do
   our retried requests don't "harmonize" making it harder for the downstream
   service to heal.
 
-  ### Example
+  ## Example
+
   ```
   defmodule MyClient do
     use Tesla
@@ -38,12 +37,15 @@ defmodule Tesla.Middleware.Retry do
   end
   ```
 
-  ### Options
-  - `:delay`        - The base delay in milliseconds (defaults to 50)
-  - `:max_retries`  - maximum number of retries (defaults to 5)
-  - `:max_delay`    - maximum delay in milliseconds (defaults to 5000)
+  ## Options
+
+  - `:delay` - The base delay in milliseconds (defaults to 50)
+  - `:max_retries` - maximum number of retries (defaults to 5)
+  - `:max_delay` - maximum delay in milliseconds (defaults to 5000)
   - `:should_retry` - function to determine if request should be retried
   """
+
+  @behaviour Tesla.Middleware
 
   @defaults [
     delay: 50,
@@ -51,7 +53,7 @@ defmodule Tesla.Middleware.Retry do
     max_delay: 5_000
   ]
 
-  @doc false
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     opts = opts || []
 

--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -1,11 +1,10 @@
 if Code.ensure_loaded?(:telemetry) do
   defmodule Tesla.Middleware.Telemetry do
-    @behaviour Tesla.Middleware
-
     @moduledoc """
     Send the request time and meta-information through telemetry.
 
-    ### Example usage
+    ## Example usage
+
     ```
     defmodule MyClient do
       use Tesla
@@ -22,7 +21,9 @@ if Code.ensure_loaded?(:telemetry) do
     Please check the [telemetry](https://hexdocs.pm/telemetry/) for the further usage.
     """
 
-    @doc false
+    @behaviour Tesla.Middleware
+
+    @impl Tesla.Middleware
     def call(env, next, _opts) do
       {time, res} = :timer.tc(Tesla, :run, [env, next])
       :telemetry.execute([:tesla, :request], %{request_time: time}, %{result: res})

--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -1,10 +1,9 @@
 defmodule Tesla.Middleware.Timeout do
-  @behaviour Tesla.Middleware
-
   @moduledoc """
   Timeout http request after X seconds.
 
-  ### Example
+  ## Example
+
   ```
   defmodule MyClient do
     use Tesla
@@ -13,13 +12,16 @@ defmodule Tesla.Middleware.Timeout do
   end
   ```
 
-  ### Options
+  ## Options
+
   - `:timeout` - number of milliseconds a request is allowed to take (defaults to 1000)
   """
 
+  @behaviour Tesla.Middleware
+
   @default_timeout 1_000
 
-  @doc false
+  @impl Tesla.Middleware
   def call(env, next, opts) do
     opts = opts || []
     timeout = Keyword.get(opts, :timeout, @default_timeout)

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -2,7 +2,7 @@ defmodule Tesla.Mock do
   @moduledoc """
   Mock adapter for better testing.
 
-  ### Setup
+  ## Setup
 
   ```
   # config/test.exs
@@ -12,16 +12,17 @@ defmodule Tesla.Mock do
   config :tesla, MyClient, adapter: Tesla.Mock
   ```
 
-  ### Example test
+  ## Example test
+
   ```
   defmodule MyAppTest do
     use ExUnit.Case
 
     setup do
-      Tesla.Mock.mock fn
+      Tesla.Mock.mock(fn
         %{method: :get} ->
           %Tesla.Env{status: 200, body: "hello"}
-      end
+      end)
 
       :ok
     end
@@ -34,31 +35,36 @@ defmodule Tesla.Mock do
   end
   ```
 
-  ### Setting up mocks
+  ## Setting up mocks
+
   ```
   # Match on method & url and return whole Tesla.Env
-  Tesla.Mock.mock fn
-    %{method: :get,  url: "http://example.com/list"} ->
+  Tesla.Mock.mock(fn
+    %{method: :get, url: "http://example.com/list"} ->
       %Tesla.Env{status: 200, body: "hello"}
-  end
+  end)
 
   # You can use any logic required
-  Tesla.Mock.mock fn env ->
+  Tesla.Mock.mock(fn env ->
     case env.url do
       "http://example.com/list" ->
         %Tesla.Env{status: 200, body: "ok!"}
+
       _ ->
         %Tesla.Env{status: 404, body: "NotFound"}
-  end
+    end
+  end)
+
 
   # mock will also accept short version of response
   # in the form of {status, headers, body}
-  Tesla.Mock.mock fn
+  Tesla.Mock.mock(fn
     %{method: :post} -> {201, %{}, %{id: 42}}
-  end
+  end)
   ```
 
-  ### Global mocks
+  ## Global mocks
+
   By default, mocks are bound to the current process,
   i.e. the process running a single test case.
   This design allows proper isolation between test cases

--- a/lib/tesla/multipart.ex
+++ b/lib/tesla/multipart.ex
@@ -2,18 +2,21 @@ defmodule Tesla.Multipart do
   @moduledoc """
   Multipart functionality.
 
-  ### Example
+  ## Example
+
   ```
   mp =
-    Multipart.new
+    Multipart.new()
     |> Multipart.add_content_type_param("charset=utf-8")
     |> Multipart.add_field("field1", "foo")
-    |> Multipart.add_field("field2", "bar", headers: [{"content-id", "1"}, {"content-type", "text/plain"}])
+    |> Multipart.add_field("field2", "bar",
+      headers: [{"content-id", "1"}, {"content-type", "text/plain"}]
+    )
     |> Multipart.add_file("test/tesla/multipart_test_file.sh")
     |> Multipart.add_file("test/tesla/multipart_test_file.sh", name: "foobar")
     |> Multipart.add_file_content("sample file content", "sample.txt")
 
-    response = client.post(url, mp)
+  response = client.post(url, mp)
   ```
   """
 
@@ -83,7 +86,8 @@ defmodule Tesla.Multipart do
   @doc """
   Add a file part. The file will be streamed.
 
-  Options:
+  ## Options
+
   - `:name` - name of form param
   - `:filename` - filename (defaults to path basename)
   - `:headers` - additional headers
@@ -107,9 +111,12 @@ defmodule Tesla.Multipart do
   end
 
   @doc """
-  Add a file part. Same of `add_file/3` but the file content is read from `data` input parameter.
+  Add a file part with value.
 
-  Options:
+  Same of `add_file/3` but the file content is read from `data` input argument.
+
+  ## Options
+
   - `:name` - name of form param
   - `:headers` - additional headers
   """
@@ -170,7 +177,6 @@ defmodule Tesla.Multipart do
     ["content-disposition: form-data; #{ds}\r\n"]
   end
 
-  @doc false
   @spec unique_string(pos_integer) :: String.t()
   defp unique_string(length) do
     Enum.reduce(1..length, [], fn _i, acc ->

--- a/mix.lock
+++ b/mix.lock
@@ -5,7 +5,7 @@
   "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.12.0", "50e17a1b116fdb7facc2fe127a94db246169f38d7627b391376a0bc418413ce1", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/support/docs.ex
+++ b/test/support/docs.ex
@@ -7,7 +7,7 @@ defmodule TeslaDocsTest do
     use Tesla, docs: false
 
     @doc """
-    Something something
+    Something something.
     """
     def custom(url), do: get(url)
   end


### PR DESCRIPTION
Update docs for consistency

- add period to the end of the first line
- apply mix format for code in doc
- remove extra blank lines
- remove colon at the end of headings
- add lines around heading / list
- use `:key` not `key`
- use `-` over `*`
- remove unrendered alignment in markdown
- use `@impl ModuleName` and drop `@doc false` for callbacks
- refer callbacks
- place @moduledoc at the top of module
- use "argument", not "parameter"
- use headings from ##