### PR TITLE
When requests fails (while using timeout addition), preserve original stacktrace

### DIFF
--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -45,7 +45,7 @@ defmodule Tesla.Middleware.Timeout do
         {:ok, func.()}
       rescue
         e in _ ->
-          {:exception, e, __STACKTRACE__}
+          {:exception, e, System.stacktrace()}
       catch
         type, value ->
           {type, value}

--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -45,7 +45,7 @@ defmodule Tesla.Middleware.Timeout do
         {:ok, func.()}
       rescue
         e in _ ->
-          {:exception, e}
+          {:exception, e, __STACKTRACE__}
       catch
         type, value ->
           {type, value}
@@ -53,7 +53,7 @@ defmodule Tesla.Middleware.Timeout do
     end)
   end
 
-  defp repass_error({:exception, error}), do: raise(error)
+  defp repass_error({:exception, error, stacktrace}), do: reraise(error, stacktrace)
 
   defp repass_error({:throw, value}), do: throw(value)
 


### PR DESCRIPTION
Otherwise the stacktrace points to;

```
(tesla) lib/tesla/middleware/timeout.ex:54: Tesla.Middleware.Timeout.repass_error/1
(tesla) lib/tesla/middleware/timeout.ex:32: Tesla.Middleware.Timeout.call/3
(...)
```

which isn't very helpful.