### PR TITLE
Bump recommended hackney to ~> 1.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ defp deps do
     {:tesla, "~> 1.3.0"},
 
     # optional, but recommended adapter
-    {:hackney, "~> 1.14.0"},
+    {:hackney, "~> 1.15.2"},
 
     # optional, required by JSON middleware
     {:jason, ">= 1.0.0"}


### PR DESCRIPTION
Due to unannounced breaking change in the OTP version 22.1 hackney below the version 1.15.2 stopped working.

Older versions are throwing `{:option, :server_only, :honor_cipher_order}` on OTP >= 22.1 and 1.15.2 fixes this issue.

Reference:
https://github.com/benoitc/hackney/issues/591
https://github.com/edgurgel/httpoison/issues/393