### PR TITLE
Refer correctly to the timeout unit used

### DIFF
--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -1,6 +1,6 @@
 defmodule Tesla.Middleware.Timeout do
   @moduledoc """
-  Timeout http request after X seconds.
+  Timeout http request after X milliseconds.
 
   ## Example
 


### PR DESCRIPTION
Hi there,

first of all thanks for Tesla it's been making my life a lot easier through the included Mock and common things like Timeout and retry :)

Just a small doc fix to refer to the time unit actually used :)

Cheers,
Tobi