### PR TITLE
Change regular expression in PathParms middleware to avoid replacing port in url

### DIFF
--- a/lib/tesla/middleware/path_params.ex
+++ b/lib/tesla/middleware/path_params.ex
@@ -24,7 +24,7 @@ defmodule Tesla.Middleware.PathParams do
 
   @behaviour Tesla.Middleware
 
-  @rx ~r/:([\w_]+)/
+  @rx ~r/:([a-zA-Z_]+)/
 
   @impl Tesla.Middleware
   def call(env, next, _) do

--- a/lib/tesla/middleware/path_params.ex
+++ b/lib/tesla/middleware/path_params.ex
@@ -24,7 +24,7 @@ defmodule Tesla.Middleware.PathParams do
 
   @behaviour Tesla.Middleware
 
-  @rx ~r/:([a-zA-Z_]+)/
+  @rx ~r/:([a-zA-Z]{1}[\w_]*)/
 
   @impl Tesla.Middleware
   def call(env, next, _) do

--- a/test/tesla/middleware/path_params_test.exs
+++ b/test/tesla/middleware/path_params_test.exs
@@ -34,4 +34,28 @@ defmodule Tesla.Middleware.PathParamsTest do
 
     assert env.url == "/users/1/p/2"
   end
+
+  test "placeholder start by number" do
+    opts = [path_params: ["1id": 1, id_post: 2]]
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/users/:1id/p/:id_post", opts: opts}, [], nil)
+
+    assert env.url == "/users/:1id/p/2"
+  end
+
+  test "placeholder with only 1 character" do
+    opts = [path_params: [i: 1, id_post: 2]]
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/users/:i/p/:id_post", opts: opts}, [], nil)
+
+    assert env.url == "/users/1/p/2"
+  end
+
+  test "placeholder with numbers, underscore and characters" do
+    opts = [path_params: [id_1_a: 1, id_post: 2]]
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/users/:id_1_a/p/:id_post", opts: opts}, [], nil)
+
+    assert env.url == "/users/1/p/2"
+  end
 end

--- a/test/tesla/middleware/path_params_test.exs
+++ b/test/tesla/middleware/path_params_test.exs
@@ -54,7 +54,8 @@ defmodule Tesla.Middleware.PathParamsTest do
   test "placeholder with numbers, underscore and characters" do
     opts = [path_params: [id_1_a: 1, id_post: 2]]
 
-    assert {:ok, env} = @middleware.call(%Env{url: "/users/:id_1_a/p/:id_post", opts: opts}, [], nil)
+    assert {:ok, env} =
+             @middleware.call(%Env{url: "/users/:id_1_a/p/:id_post", opts: opts}, [], nil)
 
     assert env.url == "/users/1/p/2"
   end

--- a/test/tesla/middleware/path_params_test.exs
+++ b/test/tesla/middleware/path_params_test.exs
@@ -43,6 +43,14 @@ defmodule Tesla.Middleware.PathParamsTest do
     assert env.url == "/users/:1id/p/2"
   end
 
+  test "placeholder with only 1 number" do
+    opts = [path_params: ["1": 1, id_post: 2]]
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/users/:1/p/:id_post", opts: opts}, [], nil)
+
+    assert env.url == "/users/:1/p/2"
+  end
+
   test "placeholder with only 1 character" do
     opts = [path_params: [i: 1, id_post: 2]]
 

--- a/test/tesla/middleware/path_params_test.exs
+++ b/test/tesla/middleware/path_params_test.exs
@@ -35,7 +35,7 @@ defmodule Tesla.Middleware.PathParamsTest do
     assert env.url == "/users/1/p/2"
   end
 
-  test "placeholder start by number" do
+  test "placeholder starts by number" do
     opts = [path_params: ["1id": 1, id_post: 2]]
 
     assert {:ok, env} = @middleware.call(%Env{url: "/users/:1id/p/:id_post", opts: opts}, [], nil)

--- a/test/tesla/middleware/path_params_test.exs
+++ b/test/tesla/middleware/path_params_test.exs
@@ -51,6 +51,22 @@ defmodule Tesla.Middleware.PathParamsTest do
     assert env.url == "/users/1/p/2"
   end
 
+  test "placeholder with multiple numbers" do
+    opts = [path_params: ["123": 1, id_post: 2]]
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/users/:123/p/:id_post", opts: opts}, [], nil)
+
+    assert env.url == "/users/:123/p/2"
+  end
+
+  test "placeholder starts by underscore" do
+    opts = [path_params: [_id: 1, id_post: 2]]
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/users/:_id/p/:id_post", opts: opts}, [], nil)
+
+    assert env.url == "/users/:_id/p/2"
+  end
+
   test "placeholder with numbers, underscore and characters" do
     opts = [path_params: [id_1_a: 1, id_post: 2]]
 


### PR DESCRIPTION
When `PathParams` middleware replaces the path params, it fails if the url contains the host with port (http://localhost: 7473/my_path/:whatever)

```elixir
** (ArgumentError) argument error
    :erlang.binary_to_existing_atom("7473", :utf8)
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:888: :erl_eval.expr_list/6
    (stdlib) erl_eval.erl:411: :erl_eval.expr/5
    (stdlib) erl_eval.erl:273: :erl_eval.expr/5
    (elixir) lib/regex.ex:731: Regex.apply_list/5
    (elixir) lib/regex.ex:726: Regex.apply_list/5
    (elixir) lib/regex.ex:668: Regex.do_replace/4
```

### Problem
It's unavoidable when using `BaseUrl`, `Telemetron.Instrumenter.Tesla` and `PathParams`. There is no order possible.

`Telemetron` needs `BaseUrl` to metric `host`, `PathParams` needs to be executed before `BaseUrl` because otherwise it would parse the port and `Telemetron` needs to be executed before `PathParams` because otherwise it would provoke high cardinality in metrics.

### Solution
Change regular expression to avoid considering numbers