### PR TITLE
Fix for timeout on tls errors in gun adapter

### DIFF
--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -370,6 +370,25 @@ defmodule Tesla.Adapter.GunTest do
     assert read_body(pid, stream, opts) |> byte_size() == 16
   end
 
+  test "on TLS errors get timeout error from await_up method" do
+    request = %Env{
+      method: :get,
+      url: "https://localhost:5443"
+    }
+
+    {time, resp} =
+      :timer.tc(fn ->
+        call(request,
+          timeout: 60_000,
+          certificates_verification: true
+        )
+      end)
+
+    assert resp == {:error, :timeout}
+
+    assert time / 1_000_000 < 6
+  end
+
   defp read_body(pid, stream, opts, acc \\ "") do
     case Gun.read_chunk(pid, stream, opts) do
       {:fin, body} ->


### PR DESCRIPTION
After opening connection with certificates verification, if there are tls errors, gun adapter will wait for messages from `gun` until receive block timeout. With big timeout it can cause processes wait for message with connection which can't be opened at all. 
We explicitly call `:gun.await_up` to speed up getting error message.