### PR TITLE
Include `Tesla.Adapter.Mint` timeout's default value in documentation

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -29,7 +29,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     ## Adapter specific options:
 
-    - `:timeout` - Time, while process, will wait for mint messages.
+    - `:timeout` - Time in milliseconds, while process, will wait for mint messages. Defaults to `2_000`.
     - `:body_as` - What will be returned in `%Tesla.Env{}` body key. Possible values - `:plain`, `:stream`, `:chunks`. Defaults to `:plain`.
       - `:plain` - as binary.
       - `:stream` - as stream. If you don't want to close connection (because you want to reuse it later) pass `close_conn: false` in adapter opts.


### PR DESCRIPTION
I thought this might be helpful for someone else in the future. I spent some time looking for the default value for `timeout` in Hexdocs until I found it in the source code.
I've also mentioned that the value is in `milliseconds` to be more explicit.

Let me know what you think. Thanks!