### PR TITLE
Add function to dynamically update existing client

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -499,6 +499,27 @@ defmodule Tesla do
   @spec client([Tesla.Client.middleware()], Tesla.Client.adapter()) :: Tesla.Client.t()
   def client(middleware, adapter \\ nil), do: Tesla.Builder.client(middleware, [], adapter)
 
+  @doc """
+  Dynamically update an existing client.
+
+  ```
+  # add dynamic middleware
+  client = %Tesla.Client{}
+  client = Tesla.update_client(client, [{Tesla.Middleware.Headers, [{"authorization", token}]}])
+  Tesla.get(client, "/path")
+
+  # configure adapter in runtime
+  client = %Tesla.Client{}
+  client = Tesla.update_client(client, [], Tesla.Adapter.Hackney)
+  client = Tesla.update_client(client, [], {Tesla.Adapter.Hackney, pool: :my_pool})
+  Tesla.get(client, "/path")
+  ```
+  """
+  @spec update_client(Tesla.Client.t(), [Tesla.Client.middleware()], Tesla.Client.adapter()) ::
+          Tesla.Client.t()
+  def update_client(client, middleware, adapter \\ nil),
+    do: Tesla.Builder.update_client(client, middleware, [], adapter)
+
   @deprecated "Use client/1 or client/2 instead"
   def build_client(pre, post \\ []), do: Tesla.Builder.client(pre, post)
 

--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -174,6 +174,21 @@ defmodule Tesla.Builder do
     %Tesla.Client{pre: runtime(pre), post: runtime(post), adapter: runtime(adapter)}
   end
 
+  def update_client(client, pre, post, adapter \\ nil)
+
+  def update_client(%Tesla.Client{} = client, pre, post, nil) do
+    %Tesla.Client{client | pre: client.pre ++ runtime(pre), post: client.post ++ runtime(post)}
+  end
+
+  def update_client(%Tesla.Client{} = client, pre, post, adapter) do
+    %Tesla.Client{
+      client
+      | pre: client.pre ++ runtime(pre),
+        post: client.post ++ runtime(post),
+        adapter: runtime(adapter)
+    }
+  end
+
   @default_opts []
 
   defp compile(nil), do: nil

--- a/test/tesla/builder_test.exs
+++ b/test/tesla/builder_test.exs
@@ -101,7 +101,7 @@ defmodule Tesla.BuilderTest do
         FinalMiddleware
       ]
 
-      client = TestClientPlug.new() |> TestClientPlug.new(middlewares)
+      client = TestClientPlug.new(TestClientPlug.new(), middlewares)
 
       assert [
                {FirstMiddleware, :call, [[]]},

--- a/test/tesla/builder_test.exs
+++ b/test/tesla/builder_test.exs
@@ -26,6 +26,10 @@ defmodule Tesla.BuilderTest do
       def new(middlewares) do
         Tesla.Builder.client(middlewares, [])
       end
+
+      def new(client, middlewares) do
+        Tesla.Builder.update_client(client, middlewares, [])
+      end
     end
 
     defmodule TestClientModule do
@@ -87,6 +91,23 @@ defmodule Tesla.BuilderTest do
                {FirstMiddleware, :call, [[]]},
                {SecondMiddleware, :call, [[options: :are, fun: 1]]},
                {:fn, fun}
+             ] = client.pre
+
+      assert is_function(fun)
+    end
+
+    test "update client" do
+      middlewares = [
+        FinalMiddleware
+      ]
+
+      client = TestClientPlug.new() |> TestClientPlug.new(middlewares)
+
+      assert [
+               {FirstMiddleware, :call, [[]]},
+               {SecondMiddleware, :call, [[options: :are, fun: 1]]},
+               {:fn, fun},
+               {FinalMiddleware, :call, [[]]}
              ] = client.pre
 
       assert is_function(fun)

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -164,6 +164,26 @@ defmodule TeslaTest do
     end
   end
 
+  describe "Dynamic update client" do
+    defmodule DynamicUpdateClient do
+      use Tesla
+
+      def help(client \\ %Tesla.Client{}) do
+        get(client, "/help")
+      end
+    end
+
+    test "override adapter - Tesla.update_client" do
+      client =
+        %Tesla.Client{}
+        |> Tesla.update_client([], fn env ->
+          {:ok, %{env | body: "new"}}
+        end)
+
+      assert {:ok, %{body: "new"}} = DynamicUpdateClient.help(client)
+    end
+  end
+
   describe "request API" do
     defmodule SimpleClient do
       use Tesla


### PR DESCRIPTION
When working with a library that uses Tesla with its own dynamic runtime like [Google's Gax](https://github.com/googleapis/elixir-google-api/blob/master/clients/gax/lib/google_api/gax/connection.ex#L52), there isn't an easy way if we also want to update the adaptor or append additional middleware.

With this PR one can do something like:

```elixir
Tesla.client([
  {Tesla.Middleware.Headers, [{"authorization", "Bearer #{token}"}
]})
|> Tesla.update_client([
  {Tesla.Middleware.Retry}
])
|> Tesla.get("/path")
```