### PR TITLE
Drop host header on redirect to a different hostname

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -88,7 +88,8 @@ defmodule Tesla.Middleware.FollowRedirects do
   end
 
   # See https://github.com/teamon/tesla/issues/362
-  @filter_headers ["authorization"]
+  # See https://github.com/teamon/tesla/issues/360
+  @filter_headers ["authorization", "host"]
   defp filter_headers(env, orig_url) do
     if URI.parse(env.url).host != URI.parse(orig_url).host do
       %{env | headers: Enum.filter(env.headers, fn {k, _} -> k not in @filter_headers end)}

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -188,7 +188,7 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
     assert env.headers == [{"X-Custom-Header", "custom value"}]
   end
 
-  describe "authorization headers" do
+  describe "headers" do
     defp setup_client(_) do
       middleware = [Tesla.Middleware.FollowRedirects]
 
@@ -260,6 +260,42 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
       assert_receive [
         {"content-type", "text/plain"}
       ]
+    end
+
+    test "Keep custom host header on redirect to a different domain", %{client: client} do
+      assert {:ok, env} =
+               Tesla.post(client, "http://example.com/keep", "",
+                 headers: [
+                   {"host", "example.xyz"}
+                 ]
+               )
+
+      # Initial request receives host header
+      assert_receive [
+        {"host", "example.xyz"}
+      ]
+
+      # Next request does not receive host header
+      assert_receive [
+        {"host", "example.xyz"}
+      ]
+    end
+
+    test "Strip custom host header on redirect to a different domain", %{client: client} do
+      assert {:ok, env} =
+               Tesla.post(client, "http://example.com/drop", "",
+                 headers: [
+                   {"host", "example.xyz"}
+                 ]
+               )
+
+      # Initial request receives host header
+      assert_receive [
+        {"host", "example.xyz"}
+      ]
+
+      # Next request does not receive host header
+      assert_receive []
     end
   end
 end

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -224,20 +224,20 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
                Tesla.post(client, "http://example.com/keep", "",
                  headers: [
                    {"content-type", "text/plain"},
-                   {"authorization", "Basic: secret"}
+                   {"authorization", "Basic Zm9vOmJhcg=="}
                  ]
                )
 
       # Initial request receives all headers
       assert_receive [
         {"content-type", "text/plain"},
-        {"authorization", "Basic: secret"}
+        {"authorization", "Basic Zm9vOmJhcg=="}
       ]
 
       # Next request also receives all headers
       assert_receive [
         {"content-type", "text/plain"},
-        {"authorization", "Basic: secret"}
+        {"authorization", "Basic Zm9vOmJhcg=="}
       ]
     end
 
@@ -246,14 +246,14 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
                Tesla.post(client, "http://example.com/drop", "",
                  headers: [
                    {"content-type", "text/plain"},
-                   {"authorization", "Basic: secret"}
+                   {"authorization", "Basic Zm9vOmJhcg=="}
                  ]
                )
 
       # Initial request receives all headers
       assert_receive [
         {"content-type", "text/plain"},
-        {"authorization", "Basic: secret"}
+        {"authorization", "Basic Zm9vOmJhcg=="}
       ]
 
       # Next request does not receive authorization header


### PR DESCRIPTION
Implements https://github.com/teamon/tesla/issues/360#issuecomment-610344872

Merge after https://github.com/teamon/tesla/pull/371 is merged