### PR TITLE
Middleware and adapter functions

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -63,21 +63,6 @@ defmodule Tesla.Env do
             __client__: nil
 end
 
-defmodule Tesla.Client do
-  @type adapter :: module | {module, any} | (Tesla.Env.t() -> Tesla.Env.result())
-  @type middleware :: module | {module, any}
-
-  @type t :: %__MODULE__{
-          pre: Tesla.Env.stack(),
-          post: Tesla.Env.stack(),
-          adapter: adapter | nil
-        }
-  defstruct fun: nil,
-            pre: [],
-            post: [],
-            adapter: nil
-end
-
 defmodule Tesla.Middleware do
   @moduledoc """
   The middleware specification

--- a/lib/tesla/client.ex
+++ b/lib/tesla/client.ex
@@ -1,0 +1,14 @@
+defmodule Tesla.Client do
+  @type adapter :: module | {module, any} | (Tesla.Env.t() -> Tesla.Env.result())
+  @type middleware :: module | {module, any}
+
+  @type t :: %__MODULE__{
+          pre: Tesla.Env.stack(),
+          post: Tesla.Env.stack(),
+          adapter: adapter | nil
+        }
+  defstruct fun: nil,
+            pre: [],
+            post: [],
+            adapter: nil
+end

--- a/lib/tesla/client.ex
+++ b/lib/tesla/client.ex
@@ -11,4 +11,40 @@ defmodule Tesla.Client do
             pre: [],
             post: [],
             adapter: nil
+
+  @doc ~S"""
+  Returns the client's adapter in the same form it was provided.
+  This can be used to copy an adapter from one client to another.
+
+  ## Example
+
+      iex> client = Tesla.client([], {Tesla.Adapter.Hackney, [recv_timeout: 30_000]})
+      iex> Tesla.Client.adapter(client)
+      {Tesla.Adapter.Hackney, [recv_timeout: 30_000]}
+  """
+  @spec adapter(t) :: adapter
+  def adapter(client) do
+    unruntime(client.adapter)
+  end
+
+  @doc ~S"""
+  Returns the client's middleware in the same form it was provided.
+  This can be used to copy middleware from one client to another.
+
+  ## Example
+
+      iex> middleware = [Tesla.Middleware.JSON, {Tesla.Middleware.BaseUrl, "https://api.github.com"}]
+      iex> client = Tesla.client(middleware)
+      iex> Tesla.Client.middleware(client)
+      [Tesla.Middleware.JSON, {Tesla.Middleware.BaseUrl, "https://api.github.com"}]
+  """
+  @spec middleware(t) :: [middleware]
+  def middleware(client) do
+    unruntime(client.pre)
+  end
+
+  defp unruntime(list) when is_list(list), do: Enum.map(list, &unruntime/1)
+  defp unruntime({module, :call, [[]]}) when is_atom(module), do: module
+  defp unruntime({module, :call, [opts]}) when is_atom(module), do: {module, opts}
+  defp unruntime({:fn, fun}) when is_function(fun), do: fun
 end

--- a/test/tesla/client_test.exs
+++ b/test/tesla/client_test.exs
@@ -1,4 +1,46 @@
 defmodule Tesla.ClientTest do
   use ExUnit.Case
   doctest Tesla.Client
+
+  describe "Tesla.Client.adapter/1" do
+    test "converts atom adapter properly" do
+      adapter = Tesla.Adapter.Httpc
+
+      client = Tesla.client([], adapter)
+
+      assert adapter == Tesla.Client.adapter(client)
+    end
+
+    test "converts tuple adapter properly" do
+      adapter = {Tesla.Adapter.Hackney, [recv_timeout: 30_000]}
+
+      client = Tesla.client([], adapter)
+
+      assert adapter == Tesla.Client.adapter(client)
+    end
+
+    test "converts function adapter properly" do
+      adapter = fn env ->
+        {:ok, %{env | body: "new"}}
+      end
+
+      client = Tesla.client([], adapter)
+
+      assert adapter == Tesla.Client.adapter(client)
+    end
+  end
+
+  describe "Tesla.Client.middleware/1" do
+    test "converts middleware properly" do
+      middlewares = [
+        FirstMiddleware,
+        {SecondMiddleware, options: :are, fun: 1},
+        fn env, _next -> env end
+      ]
+
+      client = Tesla.client(middlewares)
+
+      assert middlewares == Tesla.Client.middleware(client)
+    end
+  end
 end

--- a/test/tesla/client_test.exs
+++ b/test/tesla/client_test.exs
@@ -1,0 +1,4 @@
+defmodule Tesla.ClientTest do
+  use ExUnit.Case
+  doctest Tesla.Client
+end


### PR DESCRIPTION
Created based on feedback to #369 

The `Tesla.Client` struct has a private legacy data structure intended to support macro-friendliness. This structure is different than the supported argument structure for `Tesla.client/2`. This means that one cannot copy the middleware or adapter from one client into a new one for example.

Since the internal structure is highly likely to change, we are keeping it private and adding accessor functions (`Tesla.Client.adapter/1` and `Tesla.Client.middleware/1`) for getting a client's adapter or middleware in a format compatible with `Tesla.client/2`.

This supports a workflow like:

```elixir
def my_client(gax_client)
  middleware = Tesla.Client.middleware(gax_client)
  adapter = Tesla.Client.adapter(gax_client)
  # modify middleware and adapter as needed
  Tesla.client(middleware, adapter)
end
```