### PR TITLE
Add Metadata to Tesla.Client

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -482,7 +482,15 @@ defmodule Tesla do
   """
   if Version.match?(System.version(), "~> 1.7"), do: @doc(since: "1.2.0")
   @spec client([Tesla.Client.middleware()], Tesla.Client.adapter()) :: Tesla.Client.t()
-  def client(middleware, adapter \\ nil), do: Tesla.Builder.client(middleware, [], adapter)
+  def client(middleware, adapter_or_opts \\ nil)
+
+  def client(middleware, opts) when is_list(opts) do
+    adapter = Keyword.get(opts, :adapter)
+    metadata = Keyword.get(opts, :metadata)
+    Tesla.Builder.client(middleware, [], adapter, metadata)
+  end
+
+  def client(middleware, adapter), do: Tesla.Builder.client(middleware, [], adapter)
 
   @deprecated "Use client/1 or client/2 instead"
   def build_client(pre, post \\ []), do: Tesla.Builder.client(pre, post)

--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -164,14 +164,19 @@ defmodule Tesla.Builder do
     end
   end
 
-  def client(pre, post, adapter \\ nil)
+  def client(pre, post, adapter \\ nil, metadata \\ %{})
 
-  def client(pre, post, nil) do
-    %Tesla.Client{pre: runtime(pre), post: runtime(post)}
+  def client(pre, post, nil, metadata) do
+    %Tesla.Client{pre: runtime(pre), post: runtime(post), metadata: metadata}
   end
 
-  def client(pre, post, adapter) do
-    %Tesla.Client{pre: runtime(pre), post: runtime(post), adapter: runtime(adapter)}
+  def client(pre, post, adapter, metadata) do
+    %Tesla.Client{
+      pre: runtime(pre),
+      post: runtime(post),
+      adapter: runtime(adapter),
+      metadata: metadata
+    }
   end
 
   @default_opts []

--- a/lib/tesla/client.ex
+++ b/lib/tesla/client.ex
@@ -5,7 +5,7 @@ defmodule Tesla.Client do
   @type t :: %__MODULE__{
           pre: Tesla.Env.stack(),
           post: Tesla.Env.stack(),
-          adapter: adapter | nil
+          adapter: adapter | nil,
           metadata: map()
         }
   defstruct fun: nil,

--- a/lib/tesla/client.ex
+++ b/lib/tesla/client.ex
@@ -6,11 +6,13 @@ defmodule Tesla.Client do
           pre: Tesla.Env.stack(),
           post: Tesla.Env.stack(),
           adapter: adapter | nil
+          metadata: map()
         }
   defstruct fun: nil,
             pre: [],
             post: [],
-            adapter: nil
+            adapter: nil,
+            metadata: %{}
 
   @doc ~S"""
   Returns the client's adapter in the same form it was provided.


### PR DESCRIPTION
This adds the ability to have metadata associated with the client, that’s just carried around.

The use case I created this for was to have additional metadata (which service the client was for) in the telemetry events.

Obviously this isn't ready for merge yet (tests and specs need to be done), but I wanted to get feedback on the approach.