### PR TITLE
Add :telemetry_prefix option to Tesla.Middleware.Telemetry

### DIFF
--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -19,31 +19,25 @@ if Code.ensure_loaded?(:telemetry) do
     ```
 
     ## Options
-    - `:telemetry_prefix` - replaces default `[:tesla]` with desired Telemetry event prefix (see below)
+    - `:prefix` - replaces default `[:tesla]` with desired Telemetry event prefix (see below)
 
-    ## Custom Telemetry Prefix
+    ## Custom Prefix
 
-    All events will use a `:telemetry_prefix` which defaults to `[:tesla]`.
+    All events will use a `:prefix` which defaults to `[:tesla]`.
 
-    You can customize events by providing your own `:telemetry_prefix` locally:
+    You can customize events by providing your own `:prefix` locally:
 
     ```
     defmodule MyClient do
       use Tesla
 
-      plug Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix]
+      plug Tesla.Middleware.Telemetry, prefix: [:custom, :prefix]
 
     end
 
     :telemetry.attach("my-tesla-telemetry", [:custom, :prefix, :request, :stop], fn event, measurements, meta, config ->
       # Do something with the event
     end)
-    ```
-
-    You can configure `:telemetry_prefix` globally in your config, but if set the `:telemetry_prefix` option will override:
-
-    ```
-    config :tesla, Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix]
     ```
 
     ## Telemetry Events
@@ -74,12 +68,12 @@ if Code.ensure_loaded?(:telemetry) do
 
     @behaviour Tesla.Middleware
 
-    @default_telemetry_prefix [:tesla]
+    @default_prefix [:tesla]
 
     @impl Tesla.Middleware
     def call(env, next, opts) do
       start_time = System.monotonic_time()
-      prefix = telemetry_prefix(opts)
+      prefix = Keyword.get(opts, :prefix, @default_prefix)
 
       emit_start(%{env: env}, prefix)
 
@@ -109,14 +103,6 @@ if Code.ensure_loaded?(:telemetry) do
           emit_legacy_event(duration, result, prefix)
 
           result
-      end
-    end
-
-    defp config, do: Application.get_env(:tesla, __MODULE__, [])
-
-    defp telemetry_prefix(opts) do
-      with nil <- Keyword.get(opts, :telemetry_prefix) do
-        Keyword.get(config(), :telemetry_prefix, @default_telemetry_prefix)
       end
     end
 

--- a/test/tesla/middleware/telemetry_test.exs
+++ b/test/tesla/middleware/telemetry_test.exs
@@ -67,66 +67,11 @@ defmodule Tesla.Middleware.TelemetryTest do
     end
   end
 
-  describe "with :telemetry_prefix config" do
-    setup do
-      Application.put_env(:tesla, Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix])
-
-      on_exit(fn ->
-        Application.delete_env(:tesla, Tesla.Middleware.Telemetry)
-      end)
-
-      :ok
-    end
-
-    test "events are all emitted properly" do
-      Enum.each(["/telemetry", "/telemetry_error"], fn path ->
-        :telemetry.attach("start event", [:custom, :prefix, :request, :start], &echo_event/4, %{
-          caller: self()
-        })
-
-        :telemetry.attach("stop event", [:custom, :prefix, :request, :stop], &echo_event/4, %{
-          caller: self()
-        })
-
-        :telemetry.attach("legacy event", [:custom, :prefix, :request], &echo_event/4, %{
-          caller: self()
-        })
-
-        Client.get(path)
-
-        assert_receive {:event, [:custom, :prefix, :request, :start], %{system_time: time},
-                        %{env: %Tesla.Env{url: path, method: :get}}}
-
-        assert_receive {:event, [:custom, :prefix, :request, :stop], %{duration: time},
-                        %{env: %Tesla.Env{url: path, method: :get}}}
-
-        assert_receive {:event, [:custom, :prefix, :request], %{request_time: time},
-                        %{result: result}}
-      end)
-    end
-
-    test "with an exception raised" do
-      :telemetry.attach(
-        "with_exception",
-        [:custom, :prefix, :request, :exception],
-        &echo_event/4,
-        %{caller: self()}
-      )
-
-      assert_raise RuntimeError, fn ->
-        Client.get("/telemetry_exception")
-      end
-
-      assert_receive {:event, [:custom, :prefix, :request, :exception], %{duration: time},
-                      %{kind: kind, reason: reason, stacktrace: stacktrace}}
-    end
-  end
-
-  describe "with :telemetry_prefix option" do
-    defmodule ClientWithTelemetryPrefix do
+  describe "with :prefix" do
+    defmodule ClientWithPrefix do
       use Tesla
 
-      plug Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix]
+      plug Tesla.Middleware.Telemetry, prefix: [:custom, :prefix]
 
       adapter fn env ->
         case env.url do
@@ -151,7 +96,7 @@ defmodule Tesla.Middleware.TelemetryTest do
           caller: self()
         })
 
-        ClientWithTelemetryPrefix.get(path)
+        ClientWithPrefix.get(path)
 
         assert_receive {:event, [:custom, :prefix, :request, :start], %{system_time: time},
                         %{env: %Tesla.Env{url: path, method: :get}}}
@@ -173,78 +118,7 @@ defmodule Tesla.Middleware.TelemetryTest do
       )
 
       assert_raise RuntimeError, fn ->
-        ClientWithTelemetryPrefix.get("/telemetry_exception")
-      end
-
-      assert_receive {:event, [:custom, :prefix, :request, :exception], %{duration: time},
-                      %{kind: kind, reason: reason, stacktrace: stacktrace}}
-    end
-  end
-
-  describe "with :telemetry_prefix config and option override" do
-    setup do
-      Application.put_env(:tesla, Tesla.Middleware.Telemetry,
-        telemetry_prefix: [:different, :prefix]
-      )
-
-      on_exit(fn ->
-        Application.delete_env(:tesla, Tesla.Middleware.Telemetry)
-      end)
-
-      :ok
-    end
-
-    defmodule ClientConfigWithTelemetryPrefix do
-      use Tesla
-
-      plug Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix]
-
-      adapter fn env ->
-        case env.url do
-          "/telemetry" -> {:ok, env}
-          "/telemetry_error" -> {:error, :econnrefused}
-          "/telemetry_exception" -> raise "some exception"
-        end
-      end
-    end
-
-    test "events are all emitted properly" do
-      Enum.each(["/telemetry", "/telemetry_error"], fn path ->
-        :telemetry.attach("start event", [:custom, :prefix, :request, :start], &echo_event/4, %{
-          caller: self()
-        })
-
-        :telemetry.attach("stop event", [:custom, :prefix, :request, :stop], &echo_event/4, %{
-          caller: self()
-        })
-
-        :telemetry.attach("legacy event", [:custom, :prefix, :request], &echo_event/4, %{
-          caller: self()
-        })
-
-        ClientConfigWithTelemetryPrefix.get(path)
-
-        assert_receive {:event, [:custom, :prefix, :request, :start], %{system_time: time},
-                        %{env: %Tesla.Env{url: path, method: :get}}}
-
-        assert_receive {:event, [:custom, :prefix, :request, :stop], %{duration: time},
-                        %{env: %Tesla.Env{url: path, method: :get}}}
-
-        assert_receive {:event, [:custom, :prefix, :request], %{request_time: time},
-                        %{result: result}}
-      end)
-    end
-
-    test "with an exception raised" do
-      :telemetry.attach(
-        "with_exception",
-        [:custom, :prefix, :request, :exception],
-        &echo_event/4,
-        %{caller: self()}
-      )
-
-      assert_raise RuntimeError, fn ->
-        ClientConfigWithTelemetryPrefix.get("/telemetry_exception")
+        ClientWithPrefix.get("/telemetry_exception")
       end
 
       assert_receive {:event, [:custom, :prefix, :request, :exception], %{duration: time},

--- a/test/tesla/middleware/telemetry_test.exs
+++ b/test/tesla/middleware/telemetry_test.exs
@@ -1,6 +1,8 @@
 defmodule Tesla.Middleware.TelemetryTest do
   use ExUnit.Case, async: true
 
+  @moduletag capture_log: true
+
   defmodule Client do
     use Tesla
 
@@ -26,50 +28,122 @@ defmodule Tesla.Middleware.TelemetryTest do
     :ok
   end
 
-  test "events are all emitted properly" do
-    Enum.each(["/telemetry", "/telemetry_error"], fn path ->
-      :telemetry.attach("start event", [:tesla, :request, :start], &echo_event/4, %{
-        caller: self()
-      })
+  describe "with default config" do
+    test "events are all emitted properly" do
+      Enum.each(["/telemetry", "/telemetry_error"], fn path ->
+        :telemetry.attach("start event", [:tesla, :request, :start], &echo_event/4, %{
+          caller: self()
+        })
 
-      :telemetry.attach("stop event", [:tesla, :request, :stop], &echo_event/4, %{
-        caller: self()
-      })
+        :telemetry.attach("stop event", [:tesla, :request, :stop], &echo_event/4, %{
+          caller: self()
+        })
 
-      :telemetry.attach("legacy event", [:tesla, :request], &echo_event/4, %{
-        caller: self()
-      })
+        :telemetry.attach("legacy event", [:tesla, :request], &echo_event/4, %{
+          caller: self()
+        })
 
-      Client.get(path)
+        Client.get(path)
 
-      assert_receive {:event, [:tesla, :request, :start], %{system_time: time},
-                      %{env: %Tesla.Env{url: path, method: :get}}}
+        assert_receive {:event, [:tesla, :request, :start], %{system_time: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
 
-      assert_receive {:event, [:tesla, :request, :stop], %{duration: time},
-                      %{env: %Tesla.Env{url: path, method: :get}}}
+        assert_receive {:event, [:tesla, :request, :stop], %{duration: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
 
-      assert_receive {:event, [:tesla, :request], %{request_time: time}, %{result: result}}
-    end)
-  end
-
-  test "with an exception raised" do
-    :telemetry.attach("with_exception", [:tesla, :request, :exception], &echo_event/4, %{
-      caller: self()
-    })
-
-    assert_raise RuntimeError, fn ->
-      Client.get("/telemetry_exception")
+        assert_receive {:event, [:tesla, :request], %{request_time: time}, %{result: result}}
+      end)
     end
 
-    assert_receive {:event, [:tesla, :request, :exception], %{duration: time},
-                    %{
-                      kind: kind,
-                      reason: reason,
-                      stacktrace: stacktrace
-                    }}
+    test "with an exception raised" do
+      :telemetry.attach("with_exception", [:tesla, :request, :exception], &echo_event/4, %{
+        caller: self()
+      })
+
+      assert_raise RuntimeError, fn ->
+        Client.get("/telemetry_exception")
+      end
+
+      assert_receive {:event, [:tesla, :request, :exception], %{duration: time},
+                      %{
+                        kind: kind,
+                        reason: reason,
+                        stacktrace: stacktrace
+                      }}
+    end
+  end
+
+  describe "with :telemetry_prefix config" do
+    setup [:telemetry_prefix]
+
+    @telemetry_prefix [:custom, :prefix]
+
+    test "events are all emitted properly" do
+      Enum.each(["/telemetry", "/telemetry_error"], fn path ->
+        :telemetry.attach(
+          "start event",
+          @telemetry_prefix ++ [:request, :start],
+          &echo_event/4,
+          %{
+            caller: self()
+          }
+        )
+
+        :telemetry.attach("stop event", @telemetry_prefix ++ [:request, :stop], &echo_event/4, %{
+          caller: self()
+        })
+
+        :telemetry.attach("legacy event", @telemetry_prefix ++ [:request], &echo_event/4, %{
+          caller: self()
+        })
+
+        Client.get(path)
+
+        assert_receive {:event, @telemetry_prefix ++ [:request, :start], %{system_time: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
+
+        assert_receive {:event, @telemetry_prefix ++ [:request, :stop], %{duration: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
+
+        assert_receive {:event, @telemetry_prefix ++ [:request], %{request_time: time},
+                        %{result: result}}
+      end)
+    end
+
+    test "with an exception raised" do
+      :telemetry.attach(
+        "with_exception",
+        [:custom, :prefix, :request, :exception],
+        &echo_event/4,
+        %{
+          caller: self()
+        }
+      )
+
+      assert_raise RuntimeError, fn ->
+        Client.get("/telemetry_exception")
+      end
+
+      assert_receive {:event, @telemetry_prefix ++ [:request, :exception], %{duration: time},
+                      %{
+                        kind: kind,
+                        reason: reason,
+                        stacktrace: stacktrace
+                      }}
+    end
   end
 
   def echo_event(event, measurements, metadata, config) do
     send(config.caller, {:event, event, measurements, metadata})
+  end
+
+  defp telemetry_prefix(_) do
+    Application.put_env(:tesla, :telemetry_prefix, [:custom, :prefix])
+
+    on_exit(fn ->
+      Application.delete_env(:tesla, :telemetry_prefix)
+    end)
+
+    :ok
   end
 end

--- a/test/tesla/middleware/telemetry_test.exs
+++ b/test/tesla/middleware/telemetry_test.exs
@@ -28,7 +28,7 @@ defmodule Tesla.Middleware.TelemetryTest do
     :ok
   end
 
-  describe "with default config" do
+  describe "Telemetry" do
     test "events are all emitted properly" do
       Enum.each(["/telemetry", "/telemetry_error"], fn path ->
         :telemetry.attach("start event", [:tesla, :request, :start], &echo_event/4, %{
@@ -39,9 +39,7 @@ defmodule Tesla.Middleware.TelemetryTest do
           caller: self()
         })
 
-        :telemetry.attach("legacy event", [:tesla, :request], &echo_event/4, %{
-          caller: self()
-        })
+        :telemetry.attach("legacy event", [:tesla, :request], &echo_event/4, %{caller: self()})
 
         Client.get(path)
 
@@ -65,47 +63,44 @@ defmodule Tesla.Middleware.TelemetryTest do
       end
 
       assert_receive {:event, [:tesla, :request, :exception], %{duration: time},
-                      %{
-                        kind: kind,
-                        reason: reason,
-                        stacktrace: stacktrace
-                      }}
+                      %{kind: kind, reason: reason, stacktrace: stacktrace}}
     end
   end
 
   describe "with :telemetry_prefix config" do
-    setup [:telemetry_prefix]
+    setup do
+      Application.put_env(:tesla, Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix])
 
-    @telemetry_prefix [:custom, :prefix]
+      on_exit(fn ->
+        Application.delete_env(:tesla, Tesla.Middleware.Telemetry)
+      end)
+
+      :ok
+    end
 
     test "events are all emitted properly" do
       Enum.each(["/telemetry", "/telemetry_error"], fn path ->
-        :telemetry.attach(
-          "start event",
-          @telemetry_prefix ++ [:request, :start],
-          &echo_event/4,
-          %{
-            caller: self()
-          }
-        )
-
-        :telemetry.attach("stop event", @telemetry_prefix ++ [:request, :stop], &echo_event/4, %{
+        :telemetry.attach("start event", [:custom, :prefix, :request, :start], &echo_event/4, %{
           caller: self()
         })
 
-        :telemetry.attach("legacy event", @telemetry_prefix ++ [:request], &echo_event/4, %{
+        :telemetry.attach("stop event", [:custom, :prefix, :request, :stop], &echo_event/4, %{
+          caller: self()
+        })
+
+        :telemetry.attach("legacy event", [:custom, :prefix, :request], &echo_event/4, %{
           caller: self()
         })
 
         Client.get(path)
 
-        assert_receive {:event, @telemetry_prefix ++ [:request, :start], %{system_time: time},
+        assert_receive {:event, [:custom, :prefix, :request, :start], %{system_time: time},
                         %{env: %Tesla.Env{url: path, method: :get}}}
 
-        assert_receive {:event, @telemetry_prefix ++ [:request, :stop], %{duration: time},
+        assert_receive {:event, [:custom, :prefix, :request, :stop], %{duration: time},
                         %{env: %Tesla.Env{url: path, method: :get}}}
 
-        assert_receive {:event, @telemetry_prefix ++ [:request], %{request_time: time},
+        assert_receive {:event, [:custom, :prefix, :request], %{request_time: time},
                         %{result: result}}
       end)
     end
@@ -115,35 +110,149 @@ defmodule Tesla.Middleware.TelemetryTest do
         "with_exception",
         [:custom, :prefix, :request, :exception],
         &echo_event/4,
-        %{
-          caller: self()
-        }
+        %{caller: self()}
       )
 
       assert_raise RuntimeError, fn ->
         Client.get("/telemetry_exception")
       end
 
-      assert_receive {:event, @telemetry_prefix ++ [:request, :exception], %{duration: time},
-                      %{
-                        kind: kind,
-                        reason: reason,
-                        stacktrace: stacktrace
-                      }}
+      assert_receive {:event, [:custom, :prefix, :request, :exception], %{duration: time},
+                      %{kind: kind, reason: reason, stacktrace: stacktrace}}
+    end
+  end
+
+  describe "with :telemetry_prefix option" do
+    defmodule ClientWithTelemetryPrefix do
+      use Tesla
+
+      plug Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix]
+
+      adapter fn env ->
+        case env.url do
+          "/telemetry" -> {:ok, env}
+          "/telemetry_error" -> {:error, :econnrefused}
+          "/telemetry_exception" -> raise "some exception"
+        end
+      end
+    end
+
+    test "events are all emitted properly" do
+      Enum.each(["/telemetry", "/telemetry_error"], fn path ->
+        :telemetry.attach("start event", [:custom, :prefix, :request, :start], &echo_event/4, %{
+          caller: self()
+        })
+
+        :telemetry.attach("stop event", [:custom, :prefix, :request, :stop], &echo_event/4, %{
+          caller: self()
+        })
+
+        :telemetry.attach("legacy event", [:custom, :prefix, :request], &echo_event/4, %{
+          caller: self()
+        })
+
+        ClientWithTelemetryPrefix.get(path)
+
+        assert_receive {:event, [:custom, :prefix, :request, :start], %{system_time: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
+
+        assert_receive {:event, [:custom, :prefix, :request, :stop], %{duration: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
+
+        assert_receive {:event, [:custom, :prefix, :request], %{request_time: time},
+                        %{result: result}}
+      end)
+    end
+
+    test "with an exception raised" do
+      :telemetry.attach(
+        "with_exception",
+        [:custom, :prefix, :request, :exception],
+        &echo_event/4,
+        %{caller: self()}
+      )
+
+      assert_raise RuntimeError, fn ->
+        ClientWithTelemetryPrefix.get("/telemetry_exception")
+      end
+
+      assert_receive {:event, [:custom, :prefix, :request, :exception], %{duration: time},
+                      %{kind: kind, reason: reason, stacktrace: stacktrace}}
+    end
+  end
+
+  describe "with :telemetry_prefix config and option override" do
+    setup do
+      Application.put_env(:tesla, Tesla.Middleware.Telemetry,
+        telemetry_prefix: [:different, :prefix]
+      )
+
+      on_exit(fn ->
+        Application.delete_env(:tesla, Tesla.Middleware.Telemetry)
+      end)
+
+      :ok
+    end
+
+    defmodule ClientConfigWithTelemetryPrefix do
+      use Tesla
+
+      plug Tesla.Middleware.Telemetry, telemetry_prefix: [:custom, :prefix]
+
+      adapter fn env ->
+        case env.url do
+          "/telemetry" -> {:ok, env}
+          "/telemetry_error" -> {:error, :econnrefused}
+          "/telemetry_exception" -> raise "some exception"
+        end
+      end
+    end
+
+    test "events are all emitted properly" do
+      Enum.each(["/telemetry", "/telemetry_error"], fn path ->
+        :telemetry.attach("start event", [:custom, :prefix, :request, :start], &echo_event/4, %{
+          caller: self()
+        })
+
+        :telemetry.attach("stop event", [:custom, :prefix, :request, :stop], &echo_event/4, %{
+          caller: self()
+        })
+
+        :telemetry.attach("legacy event", [:custom, :prefix, :request], &echo_event/4, %{
+          caller: self()
+        })
+
+        ClientConfigWithTelemetryPrefix.get(path)
+
+        assert_receive {:event, [:custom, :prefix, :request, :start], %{system_time: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
+
+        assert_receive {:event, [:custom, :prefix, :request, :stop], %{duration: time},
+                        %{env: %Tesla.Env{url: path, method: :get}}}
+
+        assert_receive {:event, [:custom, :prefix, :request], %{request_time: time},
+                        %{result: result}}
+      end)
+    end
+
+    test "with an exception raised" do
+      :telemetry.attach(
+        "with_exception",
+        [:custom, :prefix, :request, :exception],
+        &echo_event/4,
+        %{caller: self()}
+      )
+
+      assert_raise RuntimeError, fn ->
+        ClientConfigWithTelemetryPrefix.get("/telemetry_exception")
+      end
+
+      assert_receive {:event, [:custom, :prefix, :request, :exception], %{duration: time},
+                      %{kind: kind, reason: reason, stacktrace: stacktrace}}
     end
   end
 
   def echo_event(event, measurements, metadata, config) do
     send(config.caller, {:event, event, measurements, metadata})
-  end
-
-  defp telemetry_prefix(_) do
-    Application.put_env(:tesla, :telemetry_prefix, [:custom, :prefix])
-
-    on_exit(fn ->
-      Application.delete_env(:tesla, :telemetry_prefix)
-    end)
-
-    :ok
   end
 end


### PR DESCRIPTION
This PR gives Tesla HTTP client users the ability to configure a `:telemetry_prefix` option at the `Tesla.Middleware.Telemetry` module or `config.ex` level. This is useful for developers creating platform-specific sdks or api clients that want Telemetry events to align more closely with their platform or app.