### PR TITLE
Fix dyalizer errors and warns

### DIFF
--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -291,6 +291,7 @@ if Code.ensure_loaded?(:gun) do
       end
     end
 
+    @dialyzer [{:nowarn_function, do_open_conn: 4}, :no_match]
     defp do_open_conn(uri, opts, gun_opts, tls_opts) do
       tcp_opts = Map.get(opts, :tcp_opts, [])
 

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -313,6 +313,7 @@ if Code.ensure_loaded?(:gun) do
       end
     end
 
+    @dialyzer [{:nowarn_function, gun_open: 4}, :no_match]
     defp gun_open(host, port, gun_opts, opts) do
       with {:ok, pid} <- :gun.open(host, port, gun_opts),
            {_, true, _} <- {:receive, opts[:receive], pid},

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -170,6 +170,7 @@ if Code.ensure_loaded?(:gun) do
       end
     end
 
+    @dialyzer [{:nowarn_function, open_conn: 2}, :no_match]
     defp open_conn(%{scheme: scheme, host: host, port: port}, %{conn: conn} = opts)
          when is_pid(conn) do
       info = :gun.info(conn)

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -310,17 +310,20 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp receive_message(conn, %{mode: :active} = opts) do
-      receive do
-        message ->
-          HTTP.stream(conn, message)
-      after
-        opts[:timeout] -> {:error, :timeout}
+    defp receive_message(conn, opts) do
+      case opts[:mode] do
+        :active ->
+          receive do
+            message ->
+              HTTP.stream(conn, message)
+          after
+            opts[:timeout] -> {:error, :timeout}
+          end
+
+        :passive ->
+          HTTP.recv(conn, 0, opts[:timeout])
       end
     end
-
-    defp receive_message(conn, %{mode: :passive} = opts),
-      do: HTTP.recv(conn, 0, opts[:timeout])
 
     defp reduce_responses(responses, ref, acc) do
       Enum.reduce(responses, acc, fn

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -310,20 +310,17 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp receive_message(conn, opts) do
-      case opts[:mode] do
-        :active ->
-          receive do
-            message ->
-              HTTP.stream(conn, message)
-          after
-            opts[:timeout] -> {:error, :timeout}
-          end
-
-        :passive ->
-          HTTP.recv(conn, 0, opts[:timeout])
+    defp receive_message(conn, %{mode: :active} = opts) do
+      receive do
+        message ->
+          HTTP.stream(conn, message)
+      after
+        opts[:timeout] -> {:error, :timeout}
       end
     end
+
+    defp receive_message(conn, %{mode: :passive} = opts),
+      do: HTTP.recv(conn, 0, opts[:timeout])
 
     defp reduce_responses(responses, ref, acc) do
       Enum.reduce(responses, acc, fn

--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -97,8 +97,12 @@ if Code.ensure_loaded?(:telemetry) do
       )
     end
 
-    defp emit_legacy_event(duration, result) do
-      if !@disable_legacy_event do
+    if @disable_legacy_event do
+      defp emit_legacy_event(duration, result) do
+        :ok
+      end
+    else
+      defp emit_legacy_event(duration, result) do
         duration_µs = System.convert_time_unit(duration, :native, :microsecond)
 
         :telemetry.execute(

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -158,7 +158,7 @@ defmodule Tesla.Mock do
         %{url: "/404"} -> json(%{"some" => "data"}, status: 404)
       end
   """
-  @spec json(body :: term, opts :: [response_opts]) :: Tesla.Env.t()
+  @spec json(body :: term, opts :: response_opts) :: Tesla.Env.t()
   def json(body, opts \\ []), do: response(json_encode(body), "application/json", opts)
 
   defp json_encode(body) do

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -178,7 +178,7 @@ defmodule Tesla.Mock do
         %{url: "/404"} -> text(%{"some" => "data"}, status: 404)
       end
   """
-  @spec text(body :: term, opts :: [response_opts]) :: Tesla.Env.t()
+  @spec text(body :: term, opts :: response_opts) :: Tesla.Env.t()
   def text(body, opts \\ []), do: response(body, "text/plain", opts)
 
   defp response(body, content_type, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Tesla.Mixfile do
       lockfile: lockfile(System.get_env("LOCKFILE")),
       test_coverage: [tool: ExCoveralls],
       dialyzer: [
-        plt_add_apps: [:inets],
+        plt_add_apps: [:inets, :idna, :ssl_verify_fun],
         plt_add_deps: :project
       ],
       docs: docs()


### PR DESCRIPTION
After struggling with a `Tesla.Mock.json/2` dialyzer warning at my application, I have found that the opts spec is a keyword list inside a list, instead of a plain keyword list.

So, I have analyzed other warnings and errors and also fixed those.

```
Checking PLT...
[:castore, :dialyxir, :elixir, :ex_doc, :exjsx, :fuse, :gun, :hackney, :ibrowse, :idna, :inets, :jason, :kernel, :logger, :mime, :mint, :mix_test_watch, :poison, :ssl, :ssl_verify_fun, :stdlib, :telemetry]
PLT is up to date!
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: '/Users/gabriel.medina/Git/tesla/_build/dev/dialyxir_erlang-22.3.4_elixir-1.10.3_deps-dev.plt',
  files: ['/Users/gabriel.medina/Git/tesla/_build/dev/lib/tesla/ebin/Elixir.Tesla.Middleware.JSON.beam',
   '/Users/gabriel.medina/Git/tesla/_build/dev/lib/tesla/ebin/Elixir.Tesla.Middleware.DecompressResponse.beam',
   '/Users/gabriel.medina/Git/tesla/_build/dev/lib/tesla/ebin/Elixir.Tesla.Middleware.Logger.beam',
   '/Users/gabriel.medina/Git/tesla/_build/dev/lib/tesla/ebin/Elixir.Tesla.Adapter.Gun.beam',
   '/Users/gabriel.medina/Git/tesla/_build/dev/lib/tesla/ebin/Elixir.Tesla.Middleware.Compression.beam',
   ...],
  warnings: [:unknown]
]
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m1.7s
done (passed successfully)
```
Edit: I suppose the CI is expected to fail at `certificates_verification` for `test/tesla/adapter/mint_test.exs:59`, as other PRs also failed at this step, is it right?