### PR TITLE
moving opts into map for mint adapter

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -67,7 +67,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     @spec read_chunk(HTTP.t(), reference(), keyword()) ::
             {:fin, HTTP.t(), binary()} | {:nofin, HTTP.t(), binary()}
     def read_chunk(conn, ref, opts) do
-      with {:ok, conn, acc} <- receive_packet(conn, ref, opts),
+      with {:ok, conn, acc} <- receive_packet(conn, ref, Enum.into(opts, %{})),
            {state, data} <- response_state(acc) do
         {:ok, conn} =
           if state == :fin and opts[:close_conn] do


### PR DESCRIPTION
Adds consistency for opts passed to `receive_packet /3`.
[As mentioned here](https://github.com/teamon/tesla/pull/393/files#r440820751) `read_chunk/3` was calling `receive_packet/3` with opts as keyword. 