### PR TITLE
Makes mint adapter only accept mint messages during receive_message/2

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -314,10 +314,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp receive_message(conn, %{mode: :active} = opts) do
       receive do
-        {tag, _, _} = message when tag in @tags ->
-          HTTP.stream(conn, message)
-
-        {tag, _} = message when tag in @tags ->
+        message when is_tuple(message) and elem(message, 0) in @tags ->
           HTTP.stream(conn, message)
       after
         opts[:timeout] -> {:error, :timeout}

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -50,6 +50,8 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     @default timeout: 2_000, body_as: :plain, close_conn: true, mode: :active
 
+    @tags [:tcp_error, :ssl_error, :tcp_closed, :ssl_closed, :tcp, :ssl]
+
     @impl Tesla.Adapter
     def call(env, opts) do
       opts = Tesla.Adapter.opts(@default, env, opts)
@@ -312,7 +314,10 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp receive_message(conn, %{mode: :active} = opts) do
       receive do
-        message ->
+        {tag, _, _} = message when tag in @tags ->
+          HTTP.stream(conn, message)
+
+        {tag, _} = message when tag in @tags ->
           HTTP.stream(conn, message)
       after
         opts[:timeout] -> {:error, :timeout}


### PR DESCRIPTION
PR to fix issue https://github.com/teamon/tesla/issues/398 