### PR TITLE
support function for BaseUrl

### DIFF
--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -30,6 +30,10 @@ defmodule Tesla.Middleware.BaseUrl do
     |> Tesla.run(next)
   end
 
+  defp apply_base(env, base) when is_function(base) do
+    apply_base(env, base.(env))
+  end
+
   defp apply_base(env, base) do
     if Regex.match?(~r/^https?:\/\//i, env.url) do
       # skip if url is already with scheme

--- a/test/tesla/middleware/base_url_test.exs
+++ b/test/tesla/middleware/base_url_test.exs
@@ -64,6 +64,11 @@ defmodule Tesla.Middleware.BaseUrlTest do
     assert env.url == "http://example.com/top/path"
   end
 
+  test "base as function" do
+    assert {:ok, env} = @middleware.call(%Env{url: "/api"}, [], fn _ -> "http://example.com" end)
+    assert env.url == "http://example.com/api"
+  end
+
   test "skip double append on http / https" do
     assert {:ok, env} = @middleware.call(%Env{url: "http://other.foo"}, [], "http://example.com")
     assert env.url == "http://other.foo"


### PR DESCRIPTION
For our use case we cannot use a static function for the BaseUrl but
rather read it from e.g. the ENV or the application config.

Also allowing a function for base gives us all these options.