### PR TITLE
Improve retry middleware option parsing

### DIFF
--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -45,6 +45,9 @@ defmodule Tesla.Middleware.Retry do
   - `:should_retry` - function to determine if request should be retried
   """
 
+  # Not necessary in Elixir 1.10+
+  use Bitwise, skip_operators: true
+
   @behaviour Tesla.Middleware
 
   @defaults [
@@ -91,8 +94,8 @@ defmodule Tesla.Middleware.Retry do
 
   # Exponential backoff with jitter
   defp backoff(cap, base, attempt) do
-    factor = :math.pow(2, attempt)
-    max_sleep = trunc(min(cap, base * factor))
+    factor = Bitwise.bsl(1, attempt)
+    max_sleep = min(cap, base * factor)
     delay = :rand.uniform(max_sleep)
 
     :timer.sleep(delay)

--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -39,9 +39,9 @@ defmodule Tesla.Middleware.Retry do
 
   ## Options
 
-  - `:delay` - The base delay in milliseconds (defaults to 50)
-  - `:max_retries` - maximum number of retries (defaults to 5)
-  - `:max_delay` - maximum delay in milliseconds (defaults to 5000)
+  - `:delay` - The base delay in milliseconds (positive integer, defaults to 50)
+  - `:max_retries` - maximum number of retries (non-negative integer, defaults to 5)
+  - `:max_delay` - maximum delay in milliseconds (positive integer, defaults to 5000)
   - `:should_retry` - function to determine if request should be retried
   """
 
@@ -60,11 +60,22 @@ defmodule Tesla.Middleware.Retry do
   def call(env, next, opts) do
     opts = opts || []
 
+    max_delay =
+      opts
+      |> Keyword.get(:max_delay, @defaults[:delay])
+      |> max(1)
+
+    delay =
+      opts
+      |> Keyword.get(:max_delay, @defaults[:delay])
+      |> max(1)
+      |> min(max_delay)
+
     context = %{
       retries: 0,
-      delay: Keyword.get(opts, :delay, @defaults[:delay]),
+      delay: delay,
       max_retries: Keyword.get(opts, :max_retries, @defaults[:max_retries]),
-      max_delay: Keyword.get(opts, :max_delay, @defaults[:max_delay]),
+      max_delay: max_delay,
       should_retry: Keyword.get(opts, :should_retry, &match?({:error, _}, &1))
     }
 

--- a/test/tesla/middleware/retry_test.exs
+++ b/test/tesla/middleware/retry_test.exs
@@ -73,6 +73,54 @@ defmodule Tesla.Middleware.RetryTest do
              ClientWithShouldRetryFunction.get("/retry_status")
   end
 
+  test "pass when max_delay option is zero" do
+    defmodule ClientWithZeroMaxDelay do
+      use Tesla
+
+      plug Tesla.Middleware.Retry, max_delay: 0
+
+      adapter LaggyAdapter
+    end
+
+    assert {:ok, %Tesla.Env{}} = ClientWithZeroMaxDelay.get("/maybe")
+  end
+
+  test "pass when max_delay option is negative" do
+    defmodule ClientWithNegativeMaxDelay do
+      use Tesla
+
+      plug Tesla.Middleware.Retry, max_delay: -1
+
+      adapter LaggyAdapter
+    end
+
+    assert {:ok, %Tesla.Env{}} = ClientWithNegativeMaxDelay.get("/maybe")
+  end
+
+  test "pass when delay option is zero" do
+    defmodule ClientWithZeroDelay do
+      use Tesla
+
+      plug Tesla.Middleware.Retry, delay: 0
+
+      adapter LaggyAdapter
+    end
+
+    assert {:ok, %Tesla.Env{}} = ClientWithZeroDelay.get("/maybe")
+  end
+
+  test "pass when delay option is negative" do
+    defmodule ClientWithNegativeDelay do
+      use Tesla
+
+      plug Tesla.Middleware.Retry, delay: -1
+
+      adapter LaggyAdapter
+    end
+
+    assert {:ok, %Tesla.Env{}} = ClientWithNegativeDelay.get("/maybe")
+  end
+
   defmodule DefunctClient do
     use Tesla
 

--- a/test/tesla/middleware/retry_test.exs
+++ b/test/tesla/middleware/retry_test.exs
@@ -73,54 +73,6 @@ defmodule Tesla.Middleware.RetryTest do
              ClientWithShouldRetryFunction.get("/retry_status")
   end
 
-  test "pass when max_delay option is zero" do
-    defmodule ClientWithZeroMaxDelay do
-      use Tesla
-
-      plug Tesla.Middleware.Retry, max_delay: 0
-
-      adapter LaggyAdapter
-    end
-
-    assert {:ok, %Tesla.Env{}} = ClientWithZeroMaxDelay.get("/maybe")
-  end
-
-  test "pass when max_delay option is negative" do
-    defmodule ClientWithNegativeMaxDelay do
-      use Tesla
-
-      plug Tesla.Middleware.Retry, max_delay: -1
-
-      adapter LaggyAdapter
-    end
-
-    assert {:ok, %Tesla.Env{}} = ClientWithNegativeMaxDelay.get("/maybe")
-  end
-
-  test "pass when delay option is zero" do
-    defmodule ClientWithZeroDelay do
-      use Tesla
-
-      plug Tesla.Middleware.Retry, delay: 0
-
-      adapter LaggyAdapter
-    end
-
-    assert {:ok, %Tesla.Env{}} = ClientWithZeroDelay.get("/maybe")
-  end
-
-  test "pass when delay option is negative" do
-    defmodule ClientWithNegativeDelay do
-      use Tesla
-
-      plug Tesla.Middleware.Retry, delay: -1
-
-      adapter LaggyAdapter
-    end
-
-    assert {:ok, %Tesla.Env{}} = ClientWithNegativeDelay.get("/maybe")
-  end
-
   defmodule DefunctClient do
     use Tesla
 
@@ -131,5 +83,65 @@ defmodule Tesla.Middleware.RetryTest do
 
   test "raise in case or unexpected error" do
     assert_raise RuntimeError, fn -> DefunctClient.get("/blow") end
+  end
+
+  test "ensures delay option is positive" do
+    defmodule ClientWithZeroDelay do
+      use Tesla
+      plug Tesla.Middleware.Retry, delay: 0
+      adapter LaggyAdapter
+    end
+
+    assert_raise ArgumentError, "expected :delay to be an integer >= 1, got 0", fn ->
+      ClientWithZeroDelay.get("/ok")
+    end
+  end
+
+  test "ensures delay option is an integer" do
+    defmodule ClientWithFloatDelay do
+      use Tesla
+      plug Tesla.Middleware.Retry, delay: 0.25
+      adapter LaggyAdapter
+    end
+
+    assert_raise ArgumentError, "expected :delay to be an integer >= 1, got 0.25", fn ->
+      ClientWithFloatDelay.get("/ok")
+    end
+  end
+
+  test "ensures max_delay option is positive" do
+    defmodule ClientWithNegativeMaxDelay do
+      use Tesla
+      plug Tesla.Middleware.Retry, max_delay: -1
+      adapter LaggyAdapter
+    end
+
+    assert_raise ArgumentError, "expected :max_delay to be an integer >= 1, got -1", fn ->
+      ClientWithNegativeMaxDelay.get("/ok")
+    end
+  end
+
+  test "ensures max_delay option is an integer" do
+    defmodule ClientWithStringMaxDelay do
+      use Tesla
+      plug Tesla.Middleware.Retry, max_delay: "500"
+      adapter LaggyAdapter
+    end
+
+    assert_raise ArgumentError, "expected :max_delay to be an integer >= 1, got \"500\"", fn ->
+      ClientWithStringMaxDelay.get("/ok")
+    end
+  end
+
+  test "ensures max_retries option is not negative" do
+    defmodule ClientWithNegativeMaxRetries do
+      use Tesla
+      plug Tesla.Middleware.Retry, max_retries: -1
+      adapter LaggyAdapter
+    end
+
+    assert_raise ArgumentError, "expected :max_retries to be an integer >= 0, got -1", fn ->
+      ClientWithNegativeMaxRetries.get("/ok")
+    end
   end
 end


### PR DESCRIPTION
When `delay` or `max_delay` are less than `1`, the Retry middleware currently crashes with the following error:

    ** (FunctionClauseError) no function clause matching in :rand.uniform_s/2
    (stdlib 3.13) rand.erl:326: :rand.uniform_s/2
    (stdlib 3.13) rand.erl:299: :rand.uniform/1
    (tesla 1.3.3) lib/tesla/middleware/retry.ex:106: Tesla.Middleware.Retry.backoff/3
    (tesla 1.3.3) lib/tesla/middleware/retry.ex:94: Tesla.Middleware.Retry.retry/3

It happens because `:rand.uniform/1` [requires](https://erlang.org/doc/man/rand.html#uniform-1) a positive integer.

### Original idea

~Make sure retry won't crash when either `delay` or `max_delay` are misconfigured.~

~This change adjusts `max_delay` to `1` when it isn't positive and also adjusts `delay` to make sure it falls within `1..max_delay`. Ideally, I believe we should will raise an `ArgumentError` right away when these values are invalid, e.g. when they are not integers, but that would be a bigger, breaking change. So this is a compromise we can safely make for now, without any behavior changes.~

### Update

This change applies strict validation to some retry middleware options. Now we explicitly fail when either one of the following misconfigurations are detected:
    
* `delay` is not a positive integer.
* `max_delay` is not a positive integer.
* `max_retries` is not a non-negative integer.