### PR TITLE
Fix compile warning in tests

### DIFF
--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -48,7 +48,7 @@ defmodule Tesla.Adapter.GunTest do
       ]
     }
 
-    assert {:ok, %Env{status: 200} = response} = call(request)
+    assert {:ok, %Env{status: 200} = _response} = call(request)
   end
 
   test "ipv4 request" do
@@ -104,7 +104,7 @@ defmodule Tesla.Adapter.GunTest do
       url: "#{@https}"
     }
 
-    assert {:ok, %Env{} = response} =
+    assert {:ok, %Env{} = _response} =
              call(request,
                certificates_verification: true,
                transport_opts: [

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -220,7 +220,7 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
     setup :setup_client
 
     test "Keep authorization header on redirect to the same domain", %{client: client} do
-      assert {:ok, env} =
+      assert {:ok, _env} =
                Tesla.post(client, "http://example.com/keep", "",
                  headers: [
                    {"content-type", "text/plain"},
@@ -242,7 +242,7 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
     end
 
     test "Strip authorization header on redirect to a different domain", %{client: client} do
-      assert {:ok, env} =
+      assert {:ok, _env} =
                Tesla.post(client, "http://example.com/drop", "",
                  headers: [
                    {"content-type", "text/plain"},
@@ -263,7 +263,7 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
     end
 
     test "Keep custom host header on redirect to a different domain", %{client: client} do
-      assert {:ok, env} =
+      assert {:ok, _env} =
                Tesla.post(client, "http://example.com/keep", "",
                  headers: [
                    {"host", "example.xyz"}
@@ -282,7 +282,7 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
     end
 
     test "Strip custom host header on redirect to a different domain", %{client: client} do
-      assert {:ok, env} =
+      assert {:ok, _env} =
                Tesla.post(client, "http://example.com/drop", "",
                  headers: [
                    {"host", "example.xyz"}

--- a/test/tesla/middleware/telemetry_test.exs
+++ b/test/tesla/middleware/telemetry_test.exs
@@ -42,13 +42,13 @@ defmodule Tesla.Middleware.TelemetryTest do
 
       Client.get(path)
 
-      assert_receive {:event, [:tesla, :request, :start], %{system_time: time},
-                      %{env: %Tesla.Env{url: path, method: :get}}}
+      assert_receive {:event, [:tesla, :request, :start], %{system_time: _time},
+                      %{env: %Tesla.Env{url: ^path, method: :get}}}
 
-      assert_receive {:event, [:tesla, :request, :stop], %{duration: time},
-                      %{env: %Tesla.Env{url: path, method: :get}}}
+      assert_receive {:event, [:tesla, :request, :stop], %{duration: _time},
+                      %{env: %Tesla.Env{url: ^path, method: :get}}}
 
-      assert_receive {:event, [:tesla, :request], %{request_time: time}, %{result: result}}
+      assert_receive {:event, [:tesla, :request], %{request_time: _time}, %{result: _result}}
     end)
   end
 
@@ -61,11 +61,11 @@ defmodule Tesla.Middleware.TelemetryTest do
       Client.get("/telemetry_exception")
     end
 
-    assert_receive {:event, [:tesla, :request, :exception], %{duration: time},
+    assert_receive {:event, [:tesla, :request, :exception], %{duration: _time},
                     %{
-                      kind: kind,
-                      reason: reason,
-                      stacktrace: stacktrace
+                      kind: _kind,
+                      reason: _reason,
+                      stacktrace: _stacktrace
                     }}
   end
 


### PR DESCRIPTION
This PR fix warning complained by Elixir compile that variable tests is unused. The PR separate in 3 commits in 3 files.