### PR TITLE
FollowRedirects middleware: copy opts from response env

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -53,6 +53,11 @@ defmodule Tesla.Middleware.FollowRedirects do
             prev_uri = URI.parse(env.url)
             next_uri = parse_location(location, res)
 
+            # Copy opts and query params from the response env,
+            # these are not modified in the adapters, but middlewares
+            # that come after might store state there
+            env = %{env | opts: res.opts}
+
             env
             |> filter_headers(prev_uri, next_uri)
             |> new_request(status, URI.to_string(next_uri))


### PR DESCRIPTION
Middlewares that come after FollowRedirects might use `opts` for state
they need to keep if they are called multiple times.

The specific use case we have that requires this: Our pool for
gun requires explicit checkout/checkin of the connection. We have a
middleware after FollowRedirects that checks out a connection, passes
it to adapter opts, requests and then checks the connection back in.
However, if `body_as: :chunks` options is used, we, obviously,
can't checkin the connection in the middleware as it needs to be passed
to the client after leaving the middleware. But if there was a redirect
to a different host we want to checkin the old connection and checkout
a new one ourselves. So we want to check if adapter options already
have a connection in them and checkin it if present.