### PR TITLE
Show the Badge status for the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tesla
 
-[![Build Status](https://github.com/teamon/tesla/workflows/Test/badge.svg)](https://github.com/teamon/tesla/actions)
+[![Build Status](https://github.com/teamon/tesla/workflows/Test/badge.svg?branch=master)](https://github.com/teamon/tesla/actions)
 [![Hex.pm](https://img.shields.io/hexpm/v/tesla.svg)](http://hex.pm/packages/tesla)
 [![Hex.pm](https://img.shields.io/hexpm/dt/tesla.svg)](https://hex.pm/packages/tesla)
 [![Hex.pm](https://img.shields.io/hexpm/dw/tesla.svg)](https://hex.pm/packages/tesla)


### PR DESCRIPTION
## Motivation

![image](https://user-images.githubusercontent.com/13632762/92477339-d1894e80-f1b6-11ea-9377-1de488c30426.png)

The badge shows the CI failing for tesla.

## Proposed solution

Ensure that the status been showed in the github actions badge is only for the master branch.