### PR TITLE
update hackney to 1.16 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ defp deps do
     {:tesla, "~> 1.3.0"},
 
     # optional, but recommended adapter
-    {:hackney, "~> 1.15.2"},
+    {:hackney, "~> 1.16.0"},
 
     # optional, required by JSON middleware
     {:jason, ">= 1.0.0"}


### PR DESCRIPTION
hackney 1.15.x gives ssl errors with OTP-23