### PR TITLE
Add private output/4 for :query

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -497,7 +497,7 @@ defmodule Tesla do
     url <> join <> encode_query(query)
   end
 
-  defp encode_query(query) do
+  def encode_query(query) do
     query
     |> Enum.flat_map(&encode_pair/1)
     |> URI.encode_query()

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -5,7 +5,7 @@ defmodule Tesla.Middleware.Logger.Formatter do
   # https://github.com/elixir-lang/elixir/blob/v1.6.4/lib/logger/lib/logger/formatter.ex
 
   @default_format "$method $url -> $status ($time ms)"
-  @keys ~w(method url status time)
+  @keys ~w(method url status time query)
 
   @type format :: [atom | binary]
 
@@ -27,6 +27,7 @@ defmodule Tesla.Middleware.Logger.Formatter do
     Enum.map(format, &output(&1, request, response, time))
   end
 
+  defp output(:query, env, _, _), do: env.query |> inspect()
   defp output(:method, env, _, _), do: env.method |> to_string() |> String.upcase()
   defp output(:url, env, _, _), do: env.url
   defp output(:status, _, {:ok, env}, _), do: to_string(env.status)

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -27,7 +27,7 @@ defmodule Tesla.Middleware.Logger.Formatter do
     Enum.map(format, &output(&1, request, response, time))
   end
 
-  defp output(:query, env, _, _), do: env.query |> inspect()
+  defp output(:query, env, _, _), do: env.query |> Tesla.encode_query()
   defp output(:method, env, _, _), do: env.method |> to_string() |> String.upcase()
   defp output(:url, env, _, _), do: env.url
   defp output(:status, _, {:ok, env}, _), do: to_string(env.status)

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -238,7 +238,7 @@ defmodule Tesla.Middleware.LoggerTest do
       res = {:error, :econnrefused}
 
       assert IO.chardata_to_string(Formatter.format(req, res, 200_000, format)) ==
-               "GET /error [] -> error: :econnrefused | 200.000"
+               "GET /error  -> error: :econnrefused | 200.000"
     end
 
     test "format ok response", %{format: format} do
@@ -246,7 +246,7 @@ defmodule Tesla.Middleware.LoggerTest do
       res = {:ok, %Tesla.Env{method: :get, url: "/ok", status: 201}}
 
       assert IO.chardata_to_string(Formatter.format(req, res, 200_000, format)) ==
-               "GET /ok [] -> 201 | 200.000"
+               "GET /ok  -> 201 | 200.000"
     end
 
     test "format query string", %{format: format} do
@@ -264,7 +264,7 @@ defmodule Tesla.Middleware.LoggerTest do
       res = {:ok, %Tesla.Env{method: :get, url: "/ok", status: 201}}
 
       assert IO.chardata_to_string(Formatter.format(req, res, 200_000, format)) ==
-               "GET /get [page: 1, sort: \"desc\", status: [\"a\", \"b\", \"c\"], user: [name: \"Jon\", age: 20]] -> 201 | 200.000"
+               "GET /get page=1&sort=desc&status%5B%5D=a&status%5B%5D=b&status%5B%5D=c&user%5Bname%5D=Jon&user%5Bage%5D=20 -> 201 | 200.000"
     end
   end
 end

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -229,7 +229,7 @@ defmodule Tesla.Middleware.LoggerTest do
 
   describe "Formatter: format/2" do
     setup do
-      format = Formatter.compile("$method $url -> $status | $time")
+      format = Formatter.compile("$method $url $query -> $status | $time")
       {:ok, format: format}
     end
 
@@ -238,7 +238,7 @@ defmodule Tesla.Middleware.LoggerTest do
       res = {:error, :econnrefused}
 
       assert IO.chardata_to_string(Formatter.format(req, res, 200_000, format)) ==
-               "GET /error -> error: :econnrefused | 200.000"
+               "GET /error [] -> error: :econnrefused | 200.000"
     end
 
     test "format ok response", %{format: format} do
@@ -246,7 +246,25 @@ defmodule Tesla.Middleware.LoggerTest do
       res = {:ok, %Tesla.Env{method: :get, url: "/ok", status: 201}}
 
       assert IO.chardata_to_string(Formatter.format(req, res, 200_000, format)) ==
-               "GET /ok -> 201 | 200.000"
+               "GET /ok [] -> 201 | 200.000"
+    end
+
+    test "format query string", %{format: format} do
+      req = %Tesla.Env{
+        method: :get,
+        url: "/get",
+        query: [
+          page: 1,
+          sort: "desc",
+          status: ["a", "b", "c"],
+          user: [name: "Jon", age: 20]
+        ]
+      }
+
+      res = {:ok, %Tesla.Env{method: :get, url: "/ok", status: 201}}
+
+      assert IO.chardata_to_string(Formatter.format(req, res, 200_000, format)) ==
+               "GET /get [page: 1, sort: \"desc\", status: [\"a\", \"b\", \"c\"], user: [name: \"Jon\", age: 20]] -> 201 | 200.000"
     end
   end
 end


### PR DESCRIPTION
This allows logger middleware to add a formatting
key for the query string. It is implemented by
piping `env.query` to inspect/1 for the sake of
simplicity.

To address #413 