### PR TITLE
Fix elixir 1.11 errors

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,11 +27,8 @@ defmodule Tesla.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: apps(Mix.env())]
+    [extra_applications: [:logger, :ssl, :inets]]
   end
-
-  def apps(:test), do: apps(:dev) ++ [:httparrot, :hackney, :ibrowse, :gun, :finch]
-  def apps(_), do: [:logger, :ssl, :inets]
 
   defp description do
     "HTTP client library, with support for middleware and multiple adapters."
@@ -78,7 +75,7 @@ defmodule Tesla.Mixfile do
       {:httparrot, "~> 1.2", only: :test},
       {:ex_doc, "~> 0.21", only: :dev},
       {:mix_test_watch, "~> 1.0", only: :dev},
-      {:dialyxir, "~> 1.0", only: [:dev, :test]},
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:inch_ex, "~> 2.0", only: :docs}
     ]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
-ExUnit.configure(trace: false)
-ExUnit.start()
+Application.ensure_all_started(:gun)
+Application.ensure_all_started(:ibrowse)
+ExUnit.start(trace: false)


### PR DESCRIPTION
## Motivation

I'm getting the following compile warnings on tesla after migrating to elixir 1.11

```
warning: :hackney.body/1 defined in application :hackney is used by the current application but the current application does not directly depend on :hackney. To fix this, you must do one of:
  1. If :hackney is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :hackney is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :hackney, you may optionally skip this warning by adding [xref: [exclude: :hackney]] to your "def project" in mix.exs
  lib/tesla/adapter/hackney.ex:91: Tesla.Adapter.Hackney.handle/1
warning: :hackney.request/5 defined in application :hackney is used by the current application but the current application does not directly depend on :hackney. To fix this, you must do one of:
  1. If :hackney is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :hackney is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :hackney, you may optionally skip this warning by adding [xref: [exclude: :hackney]] to your "def project" in mix.exs
Found at 2 locations:
  lib/tesla/adapter/hackney.ex:71: Tesla.Adapter.Hackney.request/5
  lib/tesla/adapter/hackney.ex:75: Tesla.Adapter.Hackney.request_stream/5
warning: :hackney.send_body/2 defined in application :hackney is used by the current application but the current application does not directly depend on :hackney. To fix this, you must do one of:
  1. If :hackney is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :hackney is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :hackney, you may optionally skip this warning by adding [xref: [exclude: :hackney]] to your "def project" in mix.exs
  lib/tesla/adapter/hackney.ex:76: Tesla.Adapter.Hackney.request_stream/5
warning: :hackney.start_response/1 defined in application :hackney is used by the current application but the current application does not directly depend on :hackney. To fix this, you must do one of:
  1. If :hackney is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :hackney is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :hackney, you may optionally skip this warning by adding [xref: [exclude: :hackney]] to your "def project" in mix.exs
  lib/tesla/adapter/hackney.ex:77: Tesla.Adapter.Hackney.request_stream/5
warning: MIME.from_path/1 defined in application :mime is used by the current application but the current application does not directly depend on :mime. To fix this, you must do one of:
  1. If :mime is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :mime is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :mime, you may optionally skip this warning by adding [xref: [exclude: MIME]] to your "def project" in mix.exs
  lib/tesla/multipart.ex:102: Tesla.Multipart.add_file/3
warning: :telemetry.execute/3 defined in application :telemetry is used by the current application but the current application does not directly depend on :telemetry. To fix this, you must do one of:
  1. If :telemetry is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :telemetry is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :telemetry, you may optionally skip this warning by adding [xref: [exclude: :telemetry]] to your "def project" in mix.exs
Found at 4 locations:
  lib/tesla/middleware/telemetry.ex:85: Tesla.Middleware.Telemetry.emit_start/1
  lib/tesla/middleware/telemetry.ex:93: Tesla.Middleware.Telemetry.emit_stop/2
  lib/tesla/middleware/telemetry.ex:102: Tesla.Middleware.Telemetry.emit_legacy_event/2
  lib/tesla/middleware/telemetry.ex:111: Tesla.Middleware.Telemetry.emit_exception/2
Generated tesla app
```

## Proposed solution

Use `extra_applications` options so mix can infer the dependencies.