### PR TITLE
Fix Elixir 1.11 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,10 @@ defmodule Tesla.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: apps(Mix.env())]
+    [
+      extra_applications: [:gun, :hackney, :mint, :castore, :telemetry, :mime],
+      applications: apps(Mix.env())
+    ]
   end
 
   def apps(:test), do: apps(:dev) ++ [:httparrot, :hackney, :ibrowse, :gun, :finch]


### PR DESCRIPTION
There is another PR for this, but the warnings there are different from the ones I'm fixing here, which are warning like this one:

```elixir
warning: :gun.request/6 defined in application :gun is used by the current application but the current application does not directly depend on :gun. To fix this, you must do one of:

  1. If :gun is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :gun is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :gun, you may optionally skip this warning by adding [xref: [exclude: :gun]] to your "def project" in mix.exs

Found at 2 locations:
  lib/tesla/adapter/gun.ex:355: Tesla.Adapter.Gun.open_stream/7
  lib/tesla/adapter/gun.ex:362: Tesla.Adapter.Gun.open_stream/7
```