### PR TITLE
Replace deprecated System.stacktrace() with __STACKTRACE__

### DIFF
--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -60,7 +60,7 @@ if Code.ensure_loaded?(:telemetry) do
         Tesla.run(env, next)
       catch
         kind, reason ->
-          stacktrace = System.stacktrace()
+          stacktrace = __STACKTRACE__
           duration = System.monotonic_time() - start_time
 
           emit_exception(

--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -45,7 +45,7 @@ defmodule Tesla.Middleware.Timeout do
         {:ok, func.()}
       rescue
         e in _ ->
-          {:exception, e, System.stacktrace()}
+          {:exception, e, __STACKTRACE__}
       catch
         type, value ->
           {type, value}

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -234,6 +234,6 @@ defmodule Tesla.Mock do
     fun.(env)
   rescue
     ex in FunctionClauseError ->
-      raise Tesla.Mock.Error, env: env, ex: ex, stacktrace: System.stacktrace()
+      raise Tesla.Mock.Error, env: env, ex: ex, stacktrace: __STACKTRACE__
   end
 end

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -92,7 +92,7 @@ defmodule Tesla.Middleware.TimeoutTest do
         Client.get("/raise")
       rescue
         _ in RuntimeError ->
-          [{last_module, _, _, file_info} | _] = System.stacktrace()
+          [{last_module, _, _, file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.TimeoutTest.Client == last_module
           assert [file: 'lib/tesla/builder.ex', line: 23] == file_info
@@ -107,7 +107,7 @@ defmodule Tesla.Middleware.TimeoutTest do
         Client.get("/raise")
       rescue
         _ in RuntimeError ->
-          [_, {timeout_module, _, _, module_file_info} | _] = System.stacktrace()
+          [_, {timeout_module, _, _, module_file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.Timeout == timeout_module
           assert module_file_info == [file: 'lib/tesla/middleware/timeout.ex', line: 45]


### PR DESCRIPTION
This PR replaces all deprecated `System.stacktrace()` calls with `__STACKTRACE__` ones removing these warnings from Elixir 1.11