### PR TITLE
Fix type error

### DIFF
--- a/lib/tesla/multipart.ex
+++ b/lib/tesla/multipart.ex
@@ -103,7 +103,7 @@ defmodule Tesla.Multipart do
         false -> headers
       end
 
-    data = File.stream!(path, [:read], 2048)
+    data = File.stream!(path, [], 2048)
     add_file_content(mp, data, filename, opts ++ [headers: headers])
   end
 


### PR DESCRIPTION
I've fixed a type error on `Tesla.MultiPart.add_file/3`.

I've simply removed its option because there is no `:read` option for `File.stream!/3`.
If this patch has any problems. please let me know.

Thank you!