### PR TITLE
Allow setting logger's format at runtime

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -161,7 +161,8 @@ defmodule Tesla.Middleware.Logger do
     config = Keyword.merge(@config, opts)
 
     format =
-      Keyword.get(config, :format)
+      config
+      |> Keyword.get(:format)
       |> Formatter.compile()
 
     level = log_level(response, config)

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -149,7 +149,6 @@ defmodule Tesla.Middleware.Logger do
   alias Tesla.Middleware.Logger.Formatter
 
   @config Application.get_env(:tesla, __MODULE__, [])
-  @format Formatter.compile(@config[:format])
 
   @type log_level :: :info | :warn | :error
 
@@ -161,8 +160,12 @@ defmodule Tesla.Middleware.Logger do
 
     config = Keyword.merge(@config, opts)
 
+    format =
+      Keyword.get(config, :format)
+      |> Formatter.compile()
+
     level = log_level(response, config)
-    Logger.log(level, fn -> Formatter.format(env, response, time, @format) end)
+    Logger.log(level, fn -> Formatter.format(env, response, time, format) end)
 
     if Keyword.get(config, :debug, true) do
       Logger.debug(fn -> debug(env, response, config) end)

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -149,6 +149,7 @@ defmodule Tesla.Middleware.Logger do
   alias Tesla.Middleware.Logger.Formatter
 
   @config Application.get_env(:tesla, __MODULE__, [])
+  @format Formatter.compile(@config[:format])
 
   @type log_level :: :info | :warn | :error
 
@@ -160,10 +161,10 @@ defmodule Tesla.Middleware.Logger do
 
     config = Keyword.merge(@config, opts)
 
+    optional_runtime_format = Keyword.get(config, :format)
+
     format =
-      config
-      |> Keyword.get(:format)
-      |> Formatter.compile()
+      if optional_runtime_format, do: Formatter.compile(optional_runtime_format), else: @format
 
     level = log_level(response, config)
     Logger.log(level, fn -> Formatter.format(env, response, time, format) end)


### PR DESCRIPTION
Hi, 

Currently, I am having an issue that I can't set the format of the logger at runtime because the current implementation takes the format string from the module attribute which is set at compile time. With this pull request, we will be able to set the format at run time with the below code sample.

```elixir
  middleware = [
    {Tesla.Middleware.Logger, format: "$method $url -> $status ($time ms)"}
    # ,... more middlewares
  ]

  client = Tesla.client(middleware)
```
