### PR TITLE
Use original HTTP method to retrieve digest authorization variables

### DIFF
--- a/lib/tesla/middleware/digest_auth.ex
+++ b/lib/tesla/middleware/digest_auth.ex
@@ -58,7 +58,7 @@ defmodule Tesla.Middleware.DigestAuth do
     with {:ok, unauthorized_response} <-
            env.__module__.request(
              env.__client__,
-             method: env.method,
+             method: env.opts[:pre_auth_method] || env.method,
              url: env.url,
              opts: Keyword.put(env.opts || [], :digest_auth_handshake, true)
            ) do

--- a/lib/tesla/middleware/digest_auth.ex
+++ b/lib/tesla/middleware/digest_auth.ex
@@ -56,9 +56,10 @@ defmodule Tesla.Middleware.DigestAuth do
 
   defp authorization_vars(env, opts) do
     with {:ok, unauthorized_response} <-
-           env.__module__.get(
+           env.__module__.request(
              env.__client__,
-             env.url,
+             method: env.method,
+             url: env.url,
              opts: Keyword.put(env.opts || [], :digest_auth_handshake, true)
            ) do
       {:ok,


### PR DESCRIPTION
Fixes #439 