### PR TITLE
feat: add new event metadata to tesla telemetry

### DIFF
--- a/lib/tesla/middleware/keep_request.ex
+++ b/lib/tesla/middleware/keep_request.ex
@@ -1,6 +1,6 @@
 defmodule Tesla.Middleware.KeepRequest do
   @moduledoc """
-  Store request body & headers into opts.
+  Store request body, headers and path into `%Tesla.Env{}` opts.
 
   ## Example
 
@@ -9,9 +9,10 @@ defmodule Tesla.Middleware.KeepRequest do
     use Tesla
 
     plug Tesla.Middleware.KeepRequest
+    plug Tesla.Middleware.PathParams
   end
 
-  {:ok, env} = MyClient.post("/", "request-data")
+  {:ok, env} = MyClient.post("/users/:user_id", "request-data", opts: [path_params: [user_id: "1234]])
 
   env.body
   # => "response-data"
@@ -21,6 +22,9 @@ defmodule Tesla.Middleware.KeepRequest do
 
   env.opts[:req_headers]
   # => [{"request-headers", "are-safe"}, ...]
+
+  env.opts[:req_url]
+  # => "http://localhost:8000/users/:user_id
   ```
   """
 
@@ -31,6 +35,7 @@ defmodule Tesla.Middleware.KeepRequest do
     env
     |> Tesla.put_opt(:req_body, env.body)
     |> Tesla.put_opt(:req_headers, env.headers)
+    |> Tesla.put_opt(:req_url, env.url)
     |> Tesla.run(next)
   end
 end

--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -3,7 +3,7 @@ if Code.ensure_loaded?(:telemetry) do
     @moduledoc """
     Emits events using the `:telemetry` library to expose instrumentation.
 
-    ## Example usage
+    ## Base usage
 
     ```
     defmodule MyClient do
@@ -14,6 +14,32 @@ if Code.ensure_loaded?(:telemetry) do
 
     :telemetry.attach("my-tesla-telemetry", [:tesla, :request, :stop], fn event, measurements, meta, config ->
       # Do something with the event
+    end)
+    ```
+
+    ### URL event scoping with `Tesla.Middleware.PathParams` and `Tesla.Middleware.KeepRequest`
+
+    Sometimes, it is useful to have access to a template url (i.e. `"/users/:user_id"`) for grouping
+    Telemetry events. For such cases, a combination of the `Tesla.Middleware.PathParams`,
+    `Tesla.Middleware.Telemetry` and `Tesla.Middleware.KeepRequest` may be used.
+
+    ```
+    defmodule MyClient do
+      use Tesla
+
+      # The KeepRequest middleware sets the template url as a Tesla.Env.opts entry
+      # Said entry must be used because on happy-path scenarios,
+      # the Telemetry middleware will receive the Tesla.Env.url resolved by PathParams.
+      plug Tesla.Middleware.KeepRequest
+      plug Tesla.Middleware.Telemetry
+      plug Tesla.Middleware.PathParams
+    end
+
+    :telemetry.attach("my-tesla-telemetry", [:tesla, :request, :stop], fn event, measurements, meta, config ->
+      path_params_template_url = meta.env.opts[:req_url]
+      # The meta.env.url key will only present the resolved URL on happy-path scenarios.
+      # Error cases will still return the original template url.
+      path_params_resolved_url = meta.env.url
     end)
     ```
 

--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -29,7 +29,9 @@ if Code.ensure_loaded?(:telemetry) do
 
     * `[:tesla, :request, :stop]` - emitted at the end of the request.
       * Measurement: `%{duration: native_time}`
-      * Metadata: `%{env: Tesla.Env.t()} | %{env: Tesla.Env.t(), error: term()}`
+      * Metadata: `%{env: Tesla.Env.t(), request_url: String.t()} | %{env: Tesla.Env.t(), request_url: String.t(), error: term()}`
+        `:request_url` represents the path initially received by the middleware. \
+        This is useful for use in combination with `Tesla.Middleware.PathParams`
 
     * `[:tesla, :request, :exception]` - emitted when an exception has been raised.
       * Measurement: `%{duration: native_time}`
@@ -70,10 +72,10 @@ if Code.ensure_loaded?(:telemetry) do
 
           :erlang.raise(kind, reason, stacktrace)
       else
-        {:ok, env} = result ->
+        {:ok, after_env} = result ->
           duration = System.monotonic_time() - start_time
 
-          emit_stop(duration, Map.merge(metadata, %{env: env}))
+          emit_stop(duration, Map.merge(metadata, %{env: after_env, request_url: env.url}))
           emit_legacy_event(duration, result)
 
           result
@@ -81,7 +83,11 @@ if Code.ensure_loaded?(:telemetry) do
         {:error, reason} = result ->
           duration = System.monotonic_time() - start_time
 
-          emit_stop(duration, Map.merge(metadata, %{env: env, error: reason}))
+          emit_stop(
+            duration,
+            Map.merge(metadata, %{env: env, request_url: env.url, error: reason})
+          )
+
           emit_legacy_event(duration, result)
 
           result

--- a/test/tesla/middleware/keep_request_test.exs
+++ b/test/tesla/middleware/keep_request_test.exs
@@ -3,10 +3,11 @@ defmodule Tesla.Middleware.KeepRequestTest do
 
   @middleware Tesla.Middleware.KeepRequest
 
-  test "put request body & headers into opts" do
-    env = %Tesla.Env{body: "reqbody", headers: [{"x-request", "header"}]}
+  test "put request metadata into opts" do
+    env = %Tesla.Env{url: "my_url", body: "reqbody", headers: [{"x-request", "header"}]}
     assert {:ok, env} = @middleware.call(env, [], [])
     assert env.opts[:req_body] == "reqbody"
     assert env.opts[:req_headers] == [{"x-request", "header"}]
+    assert env.opts[:req_url] == "my_url"
   end
 end

--- a/test/tesla/middleware/telemetry_test.exs
+++ b/test/tesla/middleware/telemetry_test.exs
@@ -4,13 +4,15 @@ defmodule Tesla.Middleware.TelemetryTest do
   defmodule Client do
     use Tesla
 
+    plug Tesla.Middleware.KeepRequest
     plug Tesla.Middleware.Telemetry, metadata: %{custom: "meta"}
+    plug Tesla.Middleware.PathParams
 
     adapter fn env ->
       case env.url do
-        "/telemetry" -> {:ok, env}
         "/telemetry_error" -> {:error, :econnrefused}
         "/telemetry_exception" -> raise "some exception"
+        "/telemetry" <> _ -> {:ok, env}
       end
     end
   end
@@ -63,6 +65,41 @@ defmodule Tesla.Middleware.TelemetryTest do
 
     assert_receive {:event, [:tesla, :request, :exception], %{duration: _time}, metadata}
     assert %{kind: _kind, reason: _reason, stacktrace: _stacktrace, custom: "meta"} = metadata
+  end
+
+  test "middleware works in tandem with PathParams and KeepRequest" do
+    path = "/telemetry/:event_id"
+
+    :telemetry.attach("start event", [:tesla, :request, :start], &echo_event/4, %{
+      caller: self()
+    })
+
+    :telemetry.attach("stop event", [:tesla, :request, :stop], &echo_event/4, %{
+      caller: self()
+    })
+
+    :telemetry.attach("legacy event", [:tesla, :request], &echo_event/4, %{
+      caller: self()
+    })
+
+    resolved_path = "/telemetry/my-custom-id"
+    Client.get(path, opts: [path_params: [event_id: "my-custom-id"]])
+
+    assert_receive {:event, [:tesla, :request, :start], %{system_time: _time}, metadata}
+    assert %{env: %Tesla.Env{url: ^path, method: :get}, custom: "meta"} = metadata
+
+    assert_receive {:event, [:tesla, :request, :stop], %{duration: _time}, metadata}
+
+    assert %{
+             env: %Tesla.Env{opts: opts, url: ^resolved_path, method: :get},
+             custom: "meta"
+           } = metadata
+
+    # This ensures that the unresolved PathParams template url is available
+    # for telemetry event metadata handling
+    assert path == opts[:req_url]
+
+    assert_receive {:event, [:tesla, :request], %{request_time: _time}, %{result: _result}}
   end
 
   def echo_event(event, measurements, metadata, config) do

--- a/test/tesla/middleware/telemetry_test.exs
+++ b/test/tesla/middleware/telemetry_test.exs
@@ -5,12 +5,13 @@ defmodule Tesla.Middleware.TelemetryTest do
     use Tesla
 
     plug Tesla.Middleware.Telemetry, metadata: %{custom: "meta"}
+    plug Tesla.Middleware.PathParams
 
     adapter fn env ->
       case env.url do
-        "/telemetry" -> {:ok, env}
-        "/telemetry_error" -> {:error, :econnrefused}
         "/telemetry_exception" -> raise "some exception"
+        "/telemetry_error" -> {:error, :econnrefused}
+        "/telemetry" <> _ -> {:ok, env}
       end
     end
   end
@@ -50,6 +51,38 @@ defmodule Tesla.Middleware.TelemetryTest do
 
       assert_receive {:event, [:tesla, :request], %{request_time: _time}, %{result: _result}}
     end)
+  end
+
+  test "events are all emitted properly with both resolved and unresolved path_params" do
+    path = "/telemetry/:event_id"
+
+    :telemetry.attach("start event", [:tesla, :request, :start], &echo_event/4, %{
+      caller: self()
+    })
+
+    :telemetry.attach("stop event", [:tesla, :request, :stop], &echo_event/4, %{
+      caller: self()
+    })
+
+    :telemetry.attach("legacy event", [:tesla, :request], &echo_event/4, %{
+      caller: self()
+    })
+
+    resolved_path = "/telemetry/my-custom-id"
+    Client.get(path, opts: [path_params: [event_id: "my-custom-id"]])
+
+    assert_receive {:event, [:tesla, :request, :start], %{system_time: _time}, metadata}
+    assert %{env: %Tesla.Env{url: ^path, method: :get}, custom: "meta"} = metadata
+
+    assert_receive {:event, [:tesla, :request, :stop], %{duration: _time}, metadata}
+
+    assert %{
+             env: %Tesla.Env{url: ^resolved_path, method: :get},
+             request_url: ^path,
+             custom: "meta"
+           } = metadata
+
+    assert_receive {:event, [:tesla, :request], %{request_time: _time}, %{result: _result}}
   end
 
   test "with an exception raised" do


### PR DESCRIPTION
This PR aims to provide a way for relaying through the `tesla.request.stop` event the unresolved path when using both Telemetry and PathParams middlewares.

The issue with the current implementation is that in success cases, it's impossible to retrieve the unresolved path from the event metadata