### PR TITLE
Fix race condition of Tesla.Mock.mock_global/1

### DIFF
--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -218,8 +218,14 @@ defmodule Tesla.Mock do
 
   defp agent_set(fun) do
     case Process.whereis(__MODULE__) do
-      nil -> Agent.start_link(fn -> fun end, name: __MODULE__)
-      pid -> Agent.update(pid, fn _ -> fun end)
+      nil ->
+        ExUnit.Callbacks.start_supervised!(%{
+          id: __MODULE__,
+          start: {Agent, :start_link, [fn -> fun end, [{:name, __MODULE__}]]}
+        })
+
+      pid ->
+        Agent.update(pid, fn _ -> fun end)
     end
   end
 


### PR DESCRIPTION
Problem:
Intermittent test failures when using `Tesla.Mock.mock_global/1` 
```elixir
      ** (exit) exited in: GenServer.call(#PID<0.16741.0>, {:update, #Function<2.71048325/1 in Tesla.Mock.agent_set/1>}, 5000)
          ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
      code: Tesla.Mock.mock_global(fn
      stacktrace:
        (elixir 1.10.4) lib/gen_server.ex:1023: GenServer.call/3
```

Current implementation:
`agent_set/1` is not atomic, and there's no guarantee pid returned by `Process.whereis/1` will be alive when making `Agent.update/2` call. That's because `Agent` process is linked to the test process, but the `exit(:shutdown)` signal is asynchronous, thus the same process can "leak" between test cases in certain edge cases.

Proposed implementation:
Instead of using plain `Agent.start_link/2` use `ExUnit.Callbacks.start_supervised!/1`, that puts the `Tesla.Mock` agent under the test supervision tree and guarantees the process is terminated synchronously, thus prevents the leak between test cases.