### PR TITLE
Add documentation for `options/0` type and exclude when `docs: false`

### DIFF
--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -10,6 +10,12 @@ defmodule Tesla.Builder do
       Module.register_attribute(__MODULE__, :__middleware__, accumulate: true)
       Module.register_attribute(__MODULE__, :__adapter__, [])
 
+      if unquote(docs) do
+        @typedoc "Options that may be passed to a request function. See `request/2` for detailed descriptions."
+      else
+        @typedoc false
+      end
+
       @type option ::
               {:method, Tesla.Env.method()}
               | {:url, Tesla.Env.url()}

--- a/test/tesla/builder_test.exs
+++ b/test/tesla/builder_test.exs
@@ -156,9 +156,13 @@ defmodule Tesla.BuilderTest do
                  Enum.find(docs, &match?({{:function, :get, 3}, _, _, _, _}, &1))
 
         assert doc != :hidden
+
+        assert {_, _, _, doc, _} = Enum.find(docs, &match?({{:type, :option, 0}, _, _, _, _}, &1))
+
+        assert doc != :hidden
       end
 
-      test "do not generate docs for HTTP methods when docs: false" do
+      test "do not generate docs for HTTP methods or types when docs: false" do
         {:docs_v1, _, :elixir, _, _, _, docs} = Code.fetch_docs(TeslaDocsTest.NoDocs)
 
         assert {_, _, _, doc, _} =
@@ -170,6 +174,10 @@ defmodule Tesla.BuilderTest do
                  Enum.find(docs, &match?({{:function, :custom, 1}, _, _, _, _}, &1))
 
         assert doc["en"] =~ ~r/something/
+
+        assert {_, _, _, doc, _} = Enum.find(docs, &match?({{:type, :option, 0}, _, _, _, _}, &1))
+
+        assert doc == :hidden
       end
     else
       # Use Code.get_docs/2 for elixir <1.7


### PR DESCRIPTION
Previously, in modules that `use Tesla, docs: false` the `option/0` type would
display in the generated documentation without any functions that refer to it in
the documentation.