### PR TITLE
docs: fix typo in finch adapter docs

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -42,7 +42,7 @@ if Code.ensure_loaded?(Finch) do
 
     ## [Finch options](https://hexdocs.pm/finch/Finch.html#request/3)
 
-      * `:pool_timeout` - This timeout is applied when a connection is checekd
+      * `:pool_timeout` - This timeout is applied when a connection is checked
         out from the pool. Default value is `5_000`.
 
       * `:receive_timeout` - The maximum time to wait for a response before


### PR DESCRIPTION
Fixes typo in finch adapter docs

`checekd` --> `checked`