### PR TITLE
Add BearerAuth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ This is very similar to how [Plug Router](https://github.com/elixir-plug/plug#th
 ### Auth
 
 - [`Tesla.Middleware.BasicAuth`](https://hexdocs.pm/tesla/Tesla.Middleware.BasicAuth.html) - HTTP Basic Auth
+- [`Tesla.Middleware.BearerAuth`](https://hexdocs.pm/tesla/Tesla.Middleware.BearerAuth.html) - HTTP Bearer Auth
 - [`Tesla.Middleware.DigestAuth`](https://hexdocs.pm/tesla/Tesla.Middleware.DigestAuth.html) - Digest access authentication
 
 ### Error handling

--- a/lib/tesla/middleware/bearer_auth.ex
+++ b/lib/tesla/middleware/bearer_auth.ex
@@ -1,0 +1,40 @@
+defmodule Tesla.Middleware.BearerAuth do
+  @moduledoc """
+  Bearer authentication middleware.
+
+  Adds a `{"authorization", "Bearer <token>"}` header.
+
+  ## Examples
+
+  ```
+  defmodule MyClient do
+    use Tesla
+
+    # static configuration
+    plug Tesla.Middleware.BearerAuth, token: "token"
+
+    # dynamic token
+    def new(token) do
+      Tesla.client [
+        {Tesla.Middleware.BearerAuth, token: token)}
+      ]
+    end
+  end
+  ```
+
+  ## Options
+
+  - `:token` - token (defaults to `""`)
+  """
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, opts \\ []) do
+    token = Keyword.get(opts, :token, "")
+
+    env
+    |> Tesla.put_headers([{"authorization", "Bearer #{token}"}])
+    |> Tesla.run(next)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -102,6 +102,7 @@ defmodule Tesla.Mixfile do
         Middlewares: [
           Tesla.Middleware.BaseUrl,
           Tesla.Middleware.BasicAuth,
+          Tesla.Middleware.BearerAuth,
           Tesla.Middleware.Compression,
           Tesla.Middleware.CompressRequest,
           Tesla.Middleware.DecodeFormUrlencoded,

--- a/test/tesla/middleware/bearer_auth_test.exs
+++ b/test/tesla/middleware/bearer_auth_test.exs
@@ -1,0 +1,14 @@
+defmodule Tesla.Middleware.BearerAuthTest do
+  use ExUnit.Case
+  alias Tesla.Env
+
+  @middleware Tesla.Middleware.BearerAuth
+
+  test "adds expected headers" do
+    assert {:ok, env} = @middleware.call(%Env{}, [], [])
+    assert env.headers == [{"authorization", "Bearer "}]
+
+    assert {:ok, env} = @middleware.call(%Env{}, [], token: "token")
+    assert env.headers == [{"authorization", "Bearer token"}]
+  end
+end


### PR DESCRIPTION
Adds a `Tesla.Middleware.BearerAuth` middleware.

Basically, I had to use the bearer auth method, but Tesla doesn't have a middleware for it. So here is my small contribution :)

Wanted to include a wiki article on it in the module docs, but it's only listed as a part of Oauth...