### PR TITLE
Fix typo in BearerAuth docs

### DIFF
--- a/lib/tesla/middleware/bearer_auth.ex
+++ b/lib/tesla/middleware/bearer_auth.ex
@@ -16,7 +16,7 @@ defmodule Tesla.Middleware.BearerAuth do
     # dynamic token
     def new(token) do
       Tesla.client [
-        {Tesla.Middleware.BearerAuth, token: token)}
+        {Tesla.Middleware.BearerAuth, token: token}
       ]
     end
   end


### PR DESCRIPTION
I noticed a small typo in the BearerAuth docs.

Additionally, I found that the documentation is not available on Hex.pm (https://hexdocs.pm/tesla/Tesla.Middleware.BearerAuth.html returns 404). Could the typo cause this? Anything else I can contribute to fix that?

Anyways, thanks for making my life easier with this awesome package 🙌  ❤️ 