### PR TITLE
Document that Tesla.Mock can be configured to return error tuples

### DIFF
--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -61,6 +61,12 @@ defmodule Tesla.Mock do
   Tesla.Mock.mock(fn
     %{method: :post} -> {201, %{}, %{id: 42}}
   end)
+
+  # mock will also accept error tuples in the form
+  # of {:error, reason}
+  Tesla.Mock.mock(fn
+    %{method: :post} -> {:error, :timeout}
+  end)
   ```
 
   ## Global mocks


### PR DESCRIPTION
I wasn't able to find how to do this in the documentation, but it's supported by the `call` function.  This PR adds an example to the `Setting up mocks` section of the docs.

I'm happy to rephrase things if "error tuple" is not the right term to use.