### PR TITLE
Force close connection only on redirects in Mint adapter

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -136,6 +136,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
       opts =
         opts
         |> Map.put_new(:old_conn, conn)
+        |> Map.put(:close_conn, true)
         |> Map.delete(:conn)
 
       open_conn(uri, opts)
@@ -155,8 +156,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
       with {:ok, conn} <-
              HTTP.connect(String.to_atom(uri.scheme), uri.host, uri.port, Enum.into(opts, [])) do
-        # If there were redirects, and passed `closed_conn: false`, we need to close opened connections to these intermediate hosts.
-        {:ok, conn, Map.put(opts, :close_conn, true)}
+        {:ok, conn, opts}
       end
     end
 


### PR DESCRIPTION
Currently the `Mint` adapter will force the `close_conn` option to `true` anytime the connection is opened by the adapter itself. Judging by the comment in the source, it seems that this is really only supposed to occur when there is a host mismatch with the provided `conn` (e.g. due to using `Middleware.FollowRedirects`).

It's worth noting that, as far as I can tell, the builtin adapters do not follow consistent behavior in this situation (host mismatch). The `Mint` adapter discards the provided connection and opens a new one, while the `Gun` adapter appears to just return an error.