### PR TITLE
Document that adapter options can be passed via config.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,13 @@ end
 
 ### Adapter options
 
-In case there is a need to pass specific adapter options you can do it in one of three ways:
+In case there is a need to pass specific adapter options you can do it in one of four ways:
+
+Supplying them as a keyword list in a tuple via config:
+
+```elixir
+config :tesla, adapter: {Tesla.Adapter.Hackney, [recv_timeout: 30_000]}
+```
 
 Using `adapter` macro:
 


### PR DESCRIPTION
When playing around with configuring a timeout in the Hackney adapter, I discovered that you could specify options in `config.exs` but that option wasn't documented.  This PR adds that approach to the `README`.