### PR TITLE
Support nested list of tuples in query parameters

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -537,7 +537,7 @@ defmodule Tesla do
 
   @doc false
   def encode_pair({key, value}) when is_list(value) do
-    if Keyword.keyword?(value) do
+    if Keyword.keyword?(value) or Enum.all?(value, &is_list_of_tuples?/1) do
       Enum.flat_map(value, fn {k, v} -> encode_pair({"#{key}[#{k}]", v}) end)
     else
       Enum.map(value, fn e -> {"#{key}[]", e} end)
@@ -546,4 +546,7 @@ defmodule Tesla do
 
   @doc false
   def encode_pair({key, value}), do: [{key, value}]
+
+  defp is_list_of_tuples?({k, _}) when is_binary(k), do: true
+  defp is_list_of_tuples?(_), do: false
 end

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -537,7 +537,7 @@ defmodule Tesla do
 
   @doc false
   def encode_pair({key, value}) when is_list(value) do
-    if Keyword.keyword?(value) or Enum.all?(value, &is_list_of_tuples?/1) do
+    if list_of_tuples?(value) do
       Enum.flat_map(value, fn {k, v} -> encode_pair({"#{key}[#{k}]", v}) end)
     else
       Enum.map(value, fn e -> {"#{key}[]", e} end)
@@ -547,6 +547,7 @@ defmodule Tesla do
   @doc false
   def encode_pair({key, value}), do: [{key, value}]
 
-  defp is_list_of_tuples?({k, _}) when is_binary(k), do: true
-  defp is_list_of_tuples?(_), do: false
+  defp list_of_tuples?([{k, _} | rest]) when is_atom(k) or is_binary(k), do: list_of_tuples?(rest)
+  defp list_of_tuples?([]), do: true
+  defp list_of_tuples?(_other), do: false
 end

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -284,6 +284,21 @@ defmodule TeslaTest do
       assert build_url(url, query_params) === url <> "?user=3&page=2"
     end
 
+    test "returns URL with query params from nested keyword list", %{url: url} do
+      query_params = [nested: [more_nested: [argument: 1]]]
+      assert build_url(url, query_params) === url <> "?nested%5Bmore_nested%5D%5Bargument%5D=1"
+    end
+
+    test "returns URL with query params from tuple list", %{url: url} do
+      query_params = [{"user", 3}, {"page", 2}]
+      assert build_url(url, query_params) === url <> "?user=3&page=2"
+    end
+
+    test "returns URL with query params from nested tuple list", %{url: url} do
+      query_params = [{"nested", [{"more_nested", [{"argument", 1}]}]}]
+      assert build_url(url, query_params) === url <> "?nested%5Bmore_nested%5D%5Bargument%5D=1"
+    end
+
     test "returns URL with new query params concated from keyword list", %{url: url} do
       url_with_param = url <> "?user=4"
       query_params = [page: 2, status: true]


### PR DESCRIPTION
# Description
Besides supporting nested keyword lists for query parameters, now a list of tuples where the first element of the tuple is binary is also supported.

This way there is no need to transform the list of tuples into a keyword, where the casting of keys into atoms could be dangerous when user input is used.
