### PR TITLE
Allow mime ~> 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Tesla.Mixfile do
 
   defp deps do
     [
-      {:mime, "~> 1.0"},
+      {:mime, "~> 1.0 or ~> 2.0"},
 
       # http clients
       {:ibrowse, "4.4.0", optional: true},


### PR DESCRIPTION
The major change in `mime` is that there are less supported mime types: https://github.com/elixir-plug/mime/blob/master/CHANGELOG.md

I don't think that should be a problem for this library though.