### PR TITLE
Add return type Multipart.add_field/4

### DIFF
--- a/lib/tesla/multipart.ex
+++ b/lib/tesla/multipart.ex
@@ -66,7 +66,7 @@ defmodule Tesla.Multipart do
   @doc """
   Add a field part.
   """
-  @spec add_field(t, String.t(), part_value, Keyword.t()) :: t
+  @spec add_field(t, String.t(), part_value, Keyword.t()) :: t | no_return
   def add_field(%__MODULE__{} = mp, name, value, opts \\ []) do
     :ok = assert_part_value!(value)
     {headers, opts} = Keyword.pop_first(opts, :headers, [])


### PR DESCRIPTION
added a return type because an error can occur by ":ok = assert_part_value!(value)" (71 line)