### PR TITLE
feat: add API key authorization middleware

### DIFF
--- a/lib/tesla/middleware/api_key_auth.ex
+++ b/lib/tesla/middleware/api_key_auth.ex
@@ -1,0 +1,50 @@
+defmodule Tesla.Middleware.APIKeyAuth do
+  @moduledoc """
+  API key authentication middleware.
+
+  Adds a `{name, value}` tuple to headers or query params, based on `add_to` option.
+
+  ## Examples
+  ```
+  defmodule MyClient do
+    use Tesla
+    
+    # static configuration
+    plug Tesla.Middleware.APIKeyAuth, add_to: :header, name: "X-API-KEY", value: "api_key"
+
+    # dynamic API key
+    def new(add_to, name, value) do
+      Tesla.client [
+        {Tesla.Middleware.APIKeyAuth, add_to: add_to, name: name, value: value}
+      ]
+    end
+  end
+  ```
+
+  ## Options
+
+  - `:add_to` - where to add an API key, either `:header` or `:query` (not set by default)
+  - `:name` - API key name (defaults: "")
+  - `:value` - API key value (defaults: "")
+  """
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, opts \\ []) do
+    add_to = Keyword.fetch!(opts, :add_to)
+    name = Keyword.get(opts, :name, "")
+    value = Keyword.get(opts, :value, "")
+
+    env
+    |> put_api_key(add_to, [{"#{name}", "#{value}"}])
+    |> Tesla.run(next)
+  end
+
+  defp put_api_key(env, add_to, api_key) do
+    case add_to do
+      :header -> Tesla.put_headers(env, api_key)
+      :query -> Map.update!(env, :query, &(&1 ++ api_key))
+    end
+  end
+end

--- a/test/tesla/middleware/api_key_auth_test.exs
+++ b/test/tesla/middleware/api_key_auth_test.exs
@@ -1,0 +1,39 @@
+defmodule Tesla.Middleware.APIKeyAuthTest do
+  use ExUnit.Case
+
+  alias Tesla.Middleware.APIKeyAuth
+
+  describe "raises when" do
+    test "`add_to` is not provided" do
+      assert_raise KeyError, fn ->
+        APIKeyAuth.call(%Tesla.Env{}, [], [])
+      end
+    end
+
+    test "`add_to is not :header or :query" do
+      assert_raise CaseClauseError, fn ->
+        APIKeyAuth.call(%Tesla.Env{}, [], [add_to: :cookie])
+      end
+    end
+  end
+
+  describe "adds expected" do
+    test "header when `add_to` is :header" do
+      assert {:ok, env} = APIKeyAuth.call(%Tesla.Env{}, [], [add_to: :header])
+      assert env.headers == [{"", ""}]
+
+      opts = [name: "X-API-KEY", value: "apikey", add_to: :header]
+      assert {:ok, env} = APIKeyAuth.call(%Tesla.Env{}, [], opts)
+      assert env.headers == [{"X-API-KEY", "apikey"}]
+    end
+
+    test "query param when `add_to` is :query" do
+      assert {:ok, env} = APIKeyAuth.call(%Tesla.Env{}, [], [add_to: :query])
+      assert env.query == [{"", ""}]
+
+      opts = [name: "key", value: "apikey", add_to: :query]
+      assert {:ok, env} = APIKeyAuth.call(%Tesla.Env{}, [], opts)
+      assert env.query == [{"key", "apikey"}]
+    end
+  end
+end


### PR DESCRIPTION
Follows Postman API key configuration style.
https://learning.postman.com/docs/sending-requests/authorization/#api-key