### PR TITLE
Add Tesla.Env.t() to tesla.request.exception Telemetry metadata

### DIFF
--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -38,7 +38,7 @@ if Code.ensure_loaded?(:telemetry) do
 
     * `[:tesla, :request, :exception]` - emitted when an exception has been raised.
       * Measurement: `%{duration: native_time}`
-      * Metadata: `%{kind: Exception.kind(), reason: term(), stacktrace: Exception.stacktrace()}`
+      * Metadata: `%{env: Tesla.Env.t(), kind: Exception.kind(), reason: term(), stacktrace: Exception.stacktrace()}`
 
     ## Legacy Telemetry Events
 
@@ -102,7 +102,7 @@ if Code.ensure_loaded?(:telemetry) do
 
           emit_exception(
             duration,
-            Map.merge(metadata, %{kind: kind, reason: reason, stacktrace: stacktrace})
+            Map.merge(metadata, %{env: env, kind: kind, reason: reason, stacktrace: stacktrace})
           )
 
           :erlang.raise(kind, reason, stacktrace)

--- a/test/tesla/middleware/telemetry_test.exs
+++ b/test/tesla/middleware/telemetry_test.exs
@@ -67,7 +67,14 @@ defmodule Tesla.Middleware.TelemetryTest do
     end
 
     assert_receive {:event, [:tesla, :request, :exception], %{duration: _time}, metadata}
-    assert %{kind: _kind, reason: _reason, stacktrace: _stacktrace, custom: "meta"} = metadata
+
+    assert %{
+             env: _env,
+             kind: _kind,
+             reason: _reason,
+             stacktrace: _stacktrace,
+             custom: "meta"
+           } = metadata
   end
 
   test "middleware works in tandem with PathParams and KeepRequest" do


### PR DESCRIPTION
I think it would be useful to have `Tesla.Env.t()` in "tesla.request.exception" metadata unless the are objections against it.