### PR TITLE
fix: jitter should user * instead of +

### DIFF
--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -103,7 +103,7 @@ defmodule Tesla.Middleware.Retry do
 
     # This ensures that the delay's order of magnitude is kept intact, while still having some jitter.
     # Generates a value x where 1-jitter_factor <= x <= 1 + jitter_factor
-    jitter = 1 + 2 * jitter_factor * :rand.uniform() - jitter_factor
+    jitter = 1 - jitter_factor * :rand.uniform()
 
     # The actual delay is in the range max_sleep * (1 - jitter_factor), max_sleep * (1 + jitter_factor)
     delay = trunc(max_sleep * jitter)

--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -106,7 +106,7 @@ defmodule Tesla.Middleware.Retry do
     jitter = 1 + 2 * jitter_factor * :rand.uniform() - jitter_factor
 
     # The actual delay is in the range max_sleep * (1 - jitter_factor), max_sleep * (1 + jitter_factor)
-    delay = trunc(max_sleep + jitter)
+    delay = trunc(max_sleep * jitter)
 
     :timer.sleep(delay)
   end

--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -102,10 +102,10 @@ defmodule Tesla.Middleware.Retry do
     max_sleep = min(cap, base * factor)
 
     # This ensures that the delay's order of magnitude is kept intact, while still having some jitter.
-    # Generates a value x where 1-jitter_factor <= x <= 1 + jitter_factor
+    # Generates a value x where 1 - jitter_factor <= x <= 1
     jitter = 1 - jitter_factor * :rand.uniform()
 
-    # The actual delay is in the range max_sleep * (1 - jitter_factor), max_sleep * (1 + jitter_factor)
+    # The actual delay is in the range max_sleep * (1 - jitter_factor) <= delay <= max_sleep
     delay = trunc(max_sleep * jitter)
 
     :timer.sleep(delay)


### PR DESCRIPTION
This PR is fairly straight-forward. The current implementation basically has no jitter (which isn't necessarily a serious bug, but is a bug still).