### PR TITLE
docs: enhance the Logger middleware document.

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -54,7 +54,7 @@ defmodule Tesla.Middleware.Logger do
 
   ## Options
 
-  - `:log_level` - custom function for calculating log level (see below)
+  - `:log_level` - custom option for calculating log level when get `{:ok, response}` after call.(see below)
   - `:filter_headers` - sanitizes sensitive headers before logging in debug mode (see below)
   - `:debug` - show detailed request/response logging
 
@@ -81,7 +81,7 @@ defmodule Tesla.Middleware.Logger do
   - `:warn` - for 3xx responses
   - `:info` - for 2xx responses
 
-  You can customize this setting by providing your own `log_level/1` function:
+  You can customize this setting by providing your own `log_level/1` function when you get `{:ok, response}` after call:
 
   ```
   defmodule MyClient do
@@ -97,6 +97,19 @@ defmodule Tesla.Middleware.Logger do
     end
   end
   ```
+
+  In some cases, you can also provide the build-in level directly for customization:
+
+  ```
+  defmodule MyClient do
+    use Tesla
+    plug Tesla.Middleware.Logger, log_level: :debug
+  end
+  ```
+  
+  NOTE:
+  - **If you get `{:error, whatever}`, the log_level will be `:error`.**
+  - You can get more log level information from [`Logger.Handler`](https://github.com/elixir-lang/elixir/blob/main/lib/logger/lib/logger/handler.ex)
 
   ## Logger Debug output
 


### PR DESCRIPTION
Hey @teamon , I'm trying to resolve #379, hope I understood it correctly. 

But this case confused me:

>If the request returns {:error, whatever}, the log level is always set to :error, the custom log level function is never called. The custom log level is only used when an {:ok, ...} is returned.

Which level of priority should be higher ?

- scenario A: let user's option prior to `log_level/2` whenever.
- scenario B: only apply log_level option when `{:ok, env}`. (**I took this one ATM.** )

I'm still a green hand for contribution. Please do not hesitate to give your comment or suggestion. 

😄 I welcome any questions or comments you might have. (even coding style or variable name.)
