### PR TITLE
Remove micro sign

### DIFF
--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -147,11 +147,11 @@ if Code.ensure_loaded?(:telemetry) do
       end
     else
       defp emit_legacy_event(duration, result) do
-        duration_µs = System.convert_time_unit(duration, :native, :microsecond)
+        duration = System.convert_time_unit(duration, :native, :microsecond)
 
         :telemetry.execute(
           [:tesla, :request],
-          %{request_time: duration_µs},
+          %{request_time: duration},
           %{result: result}
         )
       end


### PR DESCRIPTION
Since Elixir `>= 1.14`, it checks for mixed/disallowed unicode characters, so using the micro sign in identifiers is no longer allowed.