### PR TITLE
Add Client.update_middleware/2 function

### DIFF
--- a/test/tesla/client_test.exs
+++ b/test/tesla/client_test.exs
@@ -49,4 +49,21 @@ defmodule Tesla.ClientTest do
       assert middlewares == Tesla.Client.middleware(client)
     end
   end
+
+  describe "Tesla.Client.update_middleware/2" do
+    test "updates middleware" do
+      existing_middleware = [FirstMiddleware]
+      client = Tesla.client(existing_middleware)
+
+      updated_client =
+        Tesla.Client.update_middleware(
+          client,
+          &([{SecondMiddleware, options: :are, fun: 1}] ++ &1)
+        )
+
+      expected_middlewares = [{SecondMiddleware, options: :are, fun: 1}, FirstMiddleware]
+
+      assert expected_middlewares == Tesla.Client.middleware(updated_client)
+    end
+  end
 end


### PR DESCRIPTION
I have seen this being a pain point a few times so maybe it's useful for someone else.

A typical use-case is the following:

A third-party library (i.e GitHub) exposes a function that returns a Tesla client, but I want to append a header or add logging/telemetry to it. Currently I need to write a wrapper for Tesla.Client.middleware/1 and Tesla.client/2, this merges the two into a single function.